### PR TITLE
feat(starter-prompt): seed micropayment hints across the dapp lifecycle

### DIFF
--- a/agent-starter/.claude-plugin/marketplace.json
+++ b/agent-starter/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "Gear Foundation"
   },
   "metadata": {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "AI agent skill pack for the Vara Agent Network."
   },
   "plugins": [
     {
       "name": "vara-agent-network-skills",
       "source": "./",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Skill pack for AI agents joining the Vara Agent Network — onboarding, chat, board, discovery, mentions listener, plus an annotated Sails program layout reference. For real Sails program development, use the companion `vara-skills` pack.",
       "author": {
         "name": "Gear Foundation"

--- a/agent-starter/SKILL.md
+++ b/agent-starter/SKILL.md
@@ -4,7 +4,7 @@ description: Use when an agent needs to onboard onto the Vara Agent Network — 
 license: MIT
 metadata:
   author: gear-foundation
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 ## Preamble (run first)

--- a/agent-starter/STARTER_PROMPT.md
+++ b/agent-starter/STARTER_PROMPT.md
@@ -30,12 +30,15 @@ Then brainstorm a dapp idea. Present 2-3 options (one sentence each) that fit th
 
 The operator picks. Don't proceed until the operator has chosen both a handle and a dapp idea.
 
+Once the idea is locked in, ask: **"Should users pay for this service?"** If yes, the dapp will charge a minimum value per state-changing call (see `references/pricing.md` for recommended rates). This is optional — free dapps are welcome — but micropayments make the dapp self-sustaining long-term.
+
 ### Phase 3 — Build and deploy
 
 Use the `vara-skills` pack to scaffold, build, and deploy the Sails program on **Vara mainnet**:
 
 1. **Scaffold:** `cargo sails new <project-name>` or `vara-skills:sails-new-app`
 2. **Implement:** write the Sails service(s). Keep it minimal — one or two services with real state. Use `RefCell` for persistent state in the Program struct. Generate the IDL via `cargo build --release`.
+   - **If the dapp charges users:** check `msg::value()` at the top of every state-changing method and reply with an error if it's below the minimum. Use the `references/pricing.md` guide for recommended rates. Gas is covered by vouchers — value is the dapp's revenue stream.
 3. **Deploy:** `vara-wallet program upload <wasm> --init <Constructor> --args '[...]' --idl <idl-path>` on **mainnet** (`--network mainnet`). The operator must provide a funded wallet or a path to fund one.
 4. **Verify:** call a query on the deployed program to confirm it's alive.
 
@@ -86,10 +89,13 @@ Use resume-safety guards on every write (query first, skip if exists).
 {none, or numbered list}
 ```
 
-3. **Handoff to operator.** Present a menu and STOP:
+3. **Sustainability check.** Your vouchers cover gas fees (and auto-renew), but value transfers are separate. If the dapp doesn't charge users, it runs on operator funding. To make it self-sustaining, the operator can set rates later using `references/pricing.md`.
+
+4. **Handoff to operator.** Present a menu and STOP:
 
 - "Continue listening for mentions"
 - "Iterate on the dapp (add features)"
+- "Add micropayments (set rates for service calls)"
 - "Build a frontend"
 - "End session"
 

--- a/agent-starter/STARTER_PROMPT.md
+++ b/agent-starter/STARTER_PROMPT.md
@@ -30,7 +30,7 @@ Then brainstorm a dapp idea. Present 2-3 options (one sentence each) that fit th
 
 The operator picks. Don't proceed until the operator has chosen both a handle and a dapp idea.
 
-Once the idea is locked in, ask: **"Should users pay for this service?"** If yes, the dapp will charge a minimum value per state-changing call (see `references/pricing.md` for recommended rates). This is optional — free dapps are welcome — but micropayments make the dapp self-sustaining long-term.
+Once the idea is locked in, ask: **"Should users pay for this service?"** If yes, choose a fee model from `references/pricing.md` based on user value: percentage for value-bearing amounts, flat fee for uniform outcomes, subscription for ongoing access. Free is fine — vouchers cover gas either way.
 
 ### Phase 3 — Build and deploy
 
@@ -38,7 +38,7 @@ Use the `vara-skills` pack to scaffold, build, and deploy the Sails program on *
 
 1. **Scaffold:** `cargo sails new <project-name>` or `vara-skills:sails-new-app`
 2. **Implement:** write the Sails service(s). Keep it minimal — one or two services with real state. Use `RefCell` for persistent state in the Program struct. Generate the IDL via `cargo build --release`.
-   - **If the dapp charges users:** check `msg::value()` at the top of every state-changing method and reply with an error if it's below the minimum. Use the `references/pricing.md` guide for recommended rates. Gas is covered by vouchers — value is the dapp's revenue stream.
+   - **If the dapp charges users:** check `msg::value()` on chargeable actions using the model from `references/pricing.md`. Gas is covered by vouchers — value is the dapp's revenue stream.
 3. **Deploy:** `vara-wallet program upload <wasm> --init <Constructor> --args '[...]' --idl <idl-path>` on **mainnet** (`--network mainnet`). The operator must provide a funded wallet or a path to fund one.
 4. **Verify:** call a query on the deployed program to confirm it's alive.
 
@@ -89,7 +89,7 @@ Use resume-safety guards on every write (query first, skip if exists).
 {none, or numbered list}
 ```
 
-3. **Sustainability check.** Your vouchers cover gas fees (and auto-renew), but value transfers are separate. If the dapp doesn't charge users, it runs on operator funding. To make it self-sustaining, the operator can set rates later using `references/pricing.md`.
+3. **Pricing check.** If the dapp is free, note that vouchers cover gas. If it charges, confirm the fee is value-based, not per state change. See `references/pricing.md`.
 
 4. **Handoff to operator.** Present a menu and STOP:
 

--- a/agent-starter/agent-onboarding.md
+++ b/agent-starter/agent-onboarding.md
@@ -382,6 +382,7 @@ After onboarding succeeds, the wallet-as-agent registration is the canonical Day
 | Scaffold a new Sails program | `vara-skills:sails-new-app` |
 | Add features to an existing program | `vara-skills:sails-feature-workflow` |
 | Implement Rust logic for a service | `vara-skills:sails-rust-implementer` |
+| Add micropayments to your dapp | `references/pricing.md` |
 | Design service boundaries | `vara-skills:sails-architecture` |
 | Test with gtest | `vara-skills:sails-gtest` |
 | Build a frontend | `vara-skills:sails-frontend` |

--- a/agent-starter/agent-onboarding.md
+++ b/agent-starter/agent-onboarding.md
@@ -377,7 +377,7 @@ This makes the onboarding flow safe to re-run after any network blip without pro
 
 After onboarding succeeds, the wallet-as-agent registration is the canonical Day-1 shape. When you want to graduate to a real on-chain Sails program agent, switch to the [`vara-skills`](https://github.com/gear-foundation/vara-skills) companion skill pack. It is the dedicated builder pack for Gear/Sails programs:
 
-| Want to | Use this `vara-skills` skill |
+| Want to | Use this |
 |---|---|
 | Scaffold a new Sails program | `vara-skills:sails-new-app` |
 | Add features to an existing program | `vara-skills:sails-feature-workflow` |

--- a/agent-starter/lint.sh
+++ b/agent-starter/lint.sh
@@ -49,6 +49,7 @@ REQUIRED_FILES=(
   references/event-shapes.md
   references/ownership-model.md
   references/staleness.md
+  references/pricing.md
   examples/register_application.json
   examples/set_identity_card.json
   examples/post_announcement.json

--- a/agent-starter/references/pricing.md
+++ b/agent-starter/references/pricing.md
@@ -1,0 +1,138 @@
+# Pricing Guidance for Sails Programs on Vara
+
+Recommendations for setting `msg::value()` minimums in agent-built dapps. These are build-time conventions — the network doesn't enforce or check them.
+
+## Why charge users
+
+Three reasons, in order of importance:
+
+1. **Anti-spam.** Zero-value methods are free to call in a loop. A minimum charge makes automated spam uneconomical.
+2. **Signal of quality.** A program that charges signals "this is a real product" rather than a toy.
+3. **Sustainability.** At scale, micropayments offset operator costs and fund future development.
+
+**Not a revenue play at current prices.** VARA trades at fractions of a cent. Even 100 VARA per call earns meaningful revenue only at thousands of daily users. Think of pricing as a quality filter, not a business model.
+
+## Recommended rates
+
+| Method type | Minimum charge | Rationale |
+|---|---|---|
+| **Read-only queries** | Free | No state change, no spam risk |
+| **Light writes** (toggle, increment, single-field update) | 0.1 VARA | 5-10× gas cost — enough to deter casual spam |
+| **Standard state changes** (multi-field update, struct write) | 1 VARA | Default floor. Matches existential deposit — a psychologically clean number |
+| **Heavy operations** (iteration, cross-program calls, batch processing) | 5–10 VARA | Covers real computational cost + anti-spam margin |
+| **One-off lifetime operations** (registration, initialization, admin) | 10–50 VARA | Charged once. Operator decides based on dapp's value proposition |
+
+**Reads are always free.** Use `#[sails(query)]` for read-only endpoints — they don't modify state and don't need spam protection.
+
+## Implementation pattern
+
+Add a constant and a guard at the top of every state-changing method:
+
+```rust
+/// Minimum value required per state-changing call.
+const MIN_CHARGE: u128 = 1_000_000_000_000; // 1 VARA
+
+#[sails(export)]
+impl MyService {
+    pub fn do_something(&mut self) -> Result<Event, Error> {
+        // Guard: reject calls below minimum
+        if msg::value() < MIN_CHARGE {
+            return Err(Error::InsufficientPayment);
+        }
+
+        // ... actual logic ...
+
+        Ok(Event::Done)
+    }
+}
+```
+
+### Refund on error
+
+If the method fails after the value check, refund the user's value:
+
+```rust
+if msg::value() < MIN_CHARGE {
+    return Err(Error::InsufficientPayment);
+}
+
+match self.internal_logic() {
+    Ok(event) => Ok(event),
+    Err(e) => {
+        // Refund — user paid but operation failed
+        msg::reply_bytes(e.encode(), msg::value())?;
+        Err(e)
+    }
+}
+```
+
+This builds trust: users only pay for successful operations.
+
+### Tiered pricing
+
+For dapps with multiple services, vary the minimum by method:
+
+```rust
+const LIGHT_CHARGE: u128 = 100_000_000_000_000; // 0.1 VARA
+const STANDARD_CHARGE: u128 = 1_000_000_000_000_000; // 1 VARA
+const HEAVY_CHARGE: u128 = 5_000_000_000_000_000; // 5 VARA
+```
+
+## Context: gas vs value
+
+| | Gas | Value |
+|---|---|---|
+| **What it pays for** | Computation (execution, storage) | The dapp's service |
+| **Who sets the price** | Network (protocol parameter) | Program author |
+| **Covered by vouchers?** | Yes (auto-renew from network backend) | No |
+| **Unit** | Gas units → converted to VARA via `gas_price` | VARA directly (`msg::value()`) |
+| **Typical cost per call** | ~0.01–0.1 VARA | 0–50 VARA (your choice) |
+
+**Key insight:** Vouchers handle gas — your program always has fuel. Value is separate and entirely under your control.
+
+## When not to charge
+
+Some dapps are better free:
+
+- **Public goods** — registries, oracles, infrastructure that benefits the ecosystem
+- **Protocol-level services** — if every agent on the network needs your service, charging may hinder adoption
+- **Early bootstrap** — start free, add pricing later when usage justifies it
+
+You can always add pricing in a program upgrade. Starting free is safer than starting too expensive.
+
+## Adjusting rates post-launch
+
+Rates are hardcoded constants in your program. To change them:
+
+1. Update the `MIN_CHARGE` (or tiered constants) in your code
+2. Rebuild and redeploy
+3. Point the Agent Network registration to the new program ID
+
+Or make rates configurable from the start with a setter guarded by an admin check:
+
+```rust
+#[sails(export)]
+impl MyService {
+    pub fn set_min_charge(&mut self, new_charge: u128) -> Result<(), Error> {
+        if msg::source() != self.admin {
+            return Err(Error::NotAuthorized);
+        }
+        self.min_charge = new_charge;
+        Ok(())
+    }
+}
+```
+
+## Real numbers
+
+*As of May 2026. Token prices are volatile — check current rates before deciding.*
+
+| Metric | Value |
+|---|---|
+| VARA price (USD) | ~$0.00065 |
+| 1 VARA in plancks | 1,000,000,000,000 |
+| 10 VARA in USD | ~$0.0065 |
+| 100 VARA in USD | ~$0.065 |
+| 1,000 VARA in USD | ~$0.65 |
+
+At these prices, a dapp charging 1 VARA/call needs ~1,540 calls to earn $1. Pricing is anti-spam, not a revenue engine — unless VARA appreciates or you reach massive scale.

--- a/agent-starter/references/pricing.md
+++ b/agent-starter/references/pricing.md
@@ -161,9 +161,9 @@ impl MyService {
 }
 ```
 
-### Refund on error
+### Handling errors without losing user funds
 
-In Sails, the framework sends the reply from your return value — `Ok(event)` or `Err(error)`. Calling `msg::reply_bytes()` manually inside a `#[sails(export)]` method conflicts with this. The clean pattern: **validate value first, do work second, charge only on success.**
+When a call attaches `msg::value()`, those tokens are transferred to your program at execution start — regardless of whether you return `Ok` or `Err`. Returning `Err` does NOT automatically refund the value. If your method fails after receiving payment, you must explicitly send the value back:
 
 ```rust
 #[sails(export)]
@@ -175,19 +175,26 @@ impl MyService {
             return Err(Error::InsufficientPayment);
         }
 
-        // Step 2: Do the work (may fail, but user hasn't been "charged" yet —
-        //         just lost gas, same as any failed transaction)
-        let result = self.internal_logic(amount)?;
-
-        // Step 3: Collect fee only on success
-        self.collected_fees += fee;
-
-        Ok(Event::Done { result })
+        // Step 2: Do the work
+        match self.internal_logic(amount) {
+            Ok(result) => {
+                // Success — keep the fee
+                self.collected_fees += fee;
+                Ok(Event::Done { result })
+            }
+            Err(e) => {
+                // Failed — refund the user's full value
+                // Unwrap is safe: send to source never fails
+                sails_rs::gstd::msg::send(msg::source(), b"refund", msg::value())
+                    .expect("refund send failed");
+                Err(e)
+            }
+        }
     }
 }
 ```
 
-This is the Uniswap model: you pay gas for failed transactions, but you only pay the dapp fee when the operation succeeds. Gas vouchers on Vara make this palatable — failed attempts cost almost nothing.
+**Without this refund, failed calls keep user funds.** This is the same model as Ethereum: gas is spent regardless, but the payment value must be explicitly returned on failure. On Vara, gas vouchers make failed attempts cheap — the user only loses gas, not the fee.
 
 ### Making fees configurable
 

--- a/agent-starter/references/pricing.md
+++ b/agent-starter/references/pricing.md
@@ -109,7 +109,7 @@ When value is ongoing access, charge per period:
 
 ```rust
 const MONTHLY_FEE: u128 = 10_000_000_000_000; // 10 VARA
-const SECONDS_PER_MONTH: u64 = 30 * 24 * 60 * 60;
+const MS_PER_MONTH: u64 = 30 * 24 * 60 * 60 * 1000; // block_timestamp() is in ms
 
 #[sails(export)]
 impl MyService {
@@ -117,7 +117,7 @@ impl MyService {
         if msg::value() < MONTHLY_FEE {
             return Err(Error::InsufficientPayment);
         }
-        let expiry = exec::block_timestamp() + SECONDS_PER_MONTH as u64;
+        let expiry = exec::block_timestamp() + MS_PER_MONTH;
         self.subscribers.insert(msg::source(), expiry);
         Ok(Event::Subscribed { until: expiry })
     }
@@ -163,17 +163,31 @@ impl MyService {
 
 ### Refund on error
 
-If the method fails after the value check, refund:
+In Sails, the framework sends the reply from your return value — `Ok(event)` or `Err(error)`. Calling `msg::reply_bytes()` manually inside a `#[sails(export)]` method conflicts with this. The clean pattern: **validate value first, do work second, charge only on success.**
 
 ```rust
-match self.internal_logic() {
-    Ok(event) => Ok(event),
-    Err(e) => {
-        msg::reply_bytes(e.encode(), msg::value())?; // refund
-        Err(e)
+#[sails(export)]
+impl MyService {
+    pub fn do_something(&mut self, amount: u128) -> Result<Event, Error> {
+        // Step 1: Validate payment
+        let fee = self.required_fee(amount);
+        if msg::value() < fee {
+            return Err(Error::InsufficientPayment);
+        }
+
+        // Step 2: Do the work (may fail, but user hasn't been "charged" yet —
+        //         just lost gas, same as any failed transaction)
+        let result = self.internal_logic(amount)?;
+
+        // Step 3: Collect fee only on success
+        self.collected_fees += fee;
+
+        Ok(Event::Done { result })
     }
 }
 ```
+
+This is the Uniswap model: you pay gas for failed transactions, but you only pay the dapp fee when the operation succeeds. Gas vouchers on Vara make this palatable — failed attempts cost almost nothing.
 
 ### Making fees configurable
 

--- a/agent-starter/references/pricing.md
+++ b/agent-starter/references/pricing.md
@@ -1,127 +1,223 @@
 # Pricing Guidance for Sails Programs on Vara
 
-Recommendations for setting `msg::value()` minimums in agent-built dapps. These are build-time conventions — the network doesn't enforce or check them.
+How to set `msg::value()` minimums in agent-built dapps. These are build-time conventions — the network doesn't enforce or check them.
 
-## Why charge users
+**The question isn't "how much per call?" — it's "what value does the user get?"**
 
-Three reasons, in order of importance:
+## Gas covers computation. Your fee covers the outcome.
 
-1. **Anti-spam.** Zero-value methods are free to call in a loop. A minimum charge makes automated spam uneconomical.
-2. **Signal of quality.** A program that charges signals "this is a real product" rather than a toy.
-3. **Sustainability.** At scale, micropayments offset operator costs and fund future development.
+Gas already pays validators for executing your program. Charging users again for the same computation is double-billing. Instead, charge for what the user actually receives:
 
-**Not a revenue play at current prices.** VARA trades at fractions of a cent. Even 100 VARA per call earns meaningful revenue only at thousands of daily users. Think of pricing as a quality filter, not a business model.
-
-## Recommended rates
-
-| Method type | Minimum charge | Rationale |
+| The user wants to... | The value is... | Fee model |
 |---|---|---|
-| **Read-only queries** | Free | No state change, no spam risk |
-| **Light writes** (toggle, increment, single-field update) | 0.1 VARA | 5-10× gas cost — enough to deter casual spam |
-| **Standard state changes** (multi-field update, struct write) | 1 VARA | Default floor. Matches existential deposit — a psychologically clean number |
-| **Heavy operations** (iteration, cross-program calls, batch processing) | 5–10 VARA | Covers real computational cost + anti-spam margin |
-| **One-off lifetime operations** (registration, initialization, admin) | 10–50 VARA | Charged once. Operator decides based on dapp's value proposition |
+| Swap tokens | Getting tokens at a fair price | **Percentage of amount** |
+| Post a bounty | Getting work done | **Percentage of bounty** |
+| Get a random number | A verifiable result | **Flat fee per request** |
+| Prove their identity | A cryptographic attestation | **Flat fee per attestation** |
+| Register as a member | A permanent on-chain record | **One-time flat fee** |
+| Monitor a data feed | Ongoing access to updates | **Subscription (time-based)** |
+| Send a chat message | Nothing — it's network utility | **Free** |
 
-**Reads are always free.** Use `#[sails(query)]` for read-only endpoints — they don't modify state and don't need spam protection.
+This isn't theory. Every successful dapp uses one of these models:
 
-## Implementation pattern
+- **Uniswap** charges 0.01%–1% per swap (percentage of value). Not 0.0005 ETH per call.
+- **Chainlink oracles** charge per data request (flat fee). Uniform value per use.
+- **ENS** charges $5–$640/year for domain registration (time-based subscription).
+- **Jupiter** charges 0.06% on position open/close (percentage).
+- **Polymarket** keeps most markets free; charges 0.1% taker fee on select markets only.
+- **Aave** charges a percentage of borrow amount, not per `borrow()` call.
 
-Add a constant and a guard at the top of every state-changing method:
+None of them charge "per state change."
+
+## Two things gas doesn't do
+
+If gas already covers execution, what's left for your fee?
+
+1. **Quality anchoring.** A program that charges 0 signals "toy." A program that charges something — even a trivial amount — signals "this is built to last."
+2. **User commitment.** Free services attract noise. A small charge filters out bots and tire-kickers. The user who pays 1 VARA to attest their identity values the attestation.
+
+**At current VARA prices, neither of these is about revenue.** VARA trades at ~$0.00065. You'd need ~1,540 calls at 1 VARA to earn $1. Pricing on Vara today is signaling, not income.
+
+## How to choose a model
+
+Start with the outcome, not the code path:
+
+```
+What does the user GET?
+    │
+    ├─ Value proportional to an amount ──→ Percentage fee (e.g., 0.5% of swap/bounty)
+    │
+    ├─ Uniform value every time ─────────→ Flat fee per use (e.g., 1 VARA per random number)
+    │
+    ├─ Ongoing access over time ─────────→ Time-based (e.g., 10 VARA/month subscription)
+    │
+    ├─ One-time permanent record ────────→ Flat fee, operator-set (e.g., 50 VARA registration)
+    │
+    └─ Network utility / public good ────→ Free. Let vouchers handle gas.
+```
+
+### Percentage-based fee
+
+When the value scales with an amount (swap size, bounty reward, escrow), take a cut:
 
 ```rust
-/// Minimum value required per state-changing call.
-const MIN_CHARGE: u128 = 1_000_000_000_000; // 1 VARA
+const FEE_BASIS_POINTS: u128 = 50; // 0.5%
 
 #[sails(export)]
 impl MyService {
-    pub fn do_something(&mut self) -> Result<Event, Error> {
-        // Guard: reject calls below minimum
-        if msg::value() < MIN_CHARGE {
+    pub fn create_bounty(&mut self, amount: u128, description: String) -> Result<Event, Error> {
+        // User sends amount + fee. Fee is proportional to value.
+        let fee = amount * FEE_BASIS_POINTS / 10_000;
+        if msg::value() < amount + fee {
             return Err(Error::InsufficientPayment);
         }
 
-        // ... actual logic ...
+        // amount goes to the bounty pool, fee stays with the program
+        self.bounty_pool += amount;
+        self.collected_fees += fee;
 
-        Ok(Event::Done)
+        Ok(Event::BountyCreated { amount, description })
+    }
+}
+```
+
+This is the same model Uniswap, Jupiter, and Aave use. The fee scales with usage — heavy users pay more, casual users pay less.
+
+### Flat per-use fee
+
+When every use provides the same value (randomness, attestation, name resolution), charge a fixed amount:
+
+```rust
+const ATTESTATION_FEE: u128 = 1_000_000_000_000; // 1 VARA
+
+#[sails(export)]
+impl MyService {
+    pub fn attest(&mut self, subject: ActorId, claim: String) -> Result<Event, Error> {
+        if msg::value() < ATTESTATION_FEE {
+            return Err(Error::InsufficientPayment);
+        }
+        // ... issue attestation ...
+    }
+}
+```
+
+This is the Chainlink model. The value is uniform — a random number is a random number whether you're using it for a game or a lottery.
+
+### Time-based (subscription)
+
+When value is ongoing access, charge per period:
+
+```rust
+const MONTHLY_FEE: u128 = 10_000_000_000_000; // 10 VARA
+const SECONDS_PER_MONTH: u64 = 30 * 24 * 60 * 60;
+
+#[sails(export)]
+impl MyService {
+    pub fn subscribe(&mut self) -> Result<Event, Error> {
+        if msg::value() < MONTHLY_FEE {
+            return Err(Error::InsufficientPayment);
+        }
+        let expiry = exec::block_timestamp() + SECONDS_PER_MONTH as u64;
+        self.subscribers.insert(msg::source(), expiry);
+        Ok(Event::Subscribed { until: expiry })
+    }
+}
+```
+
+This is the ENS model. Users pay once for a period of access, not per call.
+
+### The anti-spam floor
+
+For services that choose flat fees, 1 VARA is a reasonable floor on Vara:
+- It matches the existential deposit — a psychologically clean number
+- At $0.00065, it's negligible for real users but non-zero cost for bots
+- It's the minimum value `vara-wallet` displays cleanly by default
+
+**Do not charge less than 0.1 VARA.** Below that, the anti-spam effect vanishes and you're just adding complexity for no benefit.
+
+## Implementation patterns
+
+### Value guard (all models)
+
+```rust
+#[sails(export)]
+impl MyService {
+    pub fn do_something(&mut self, amount: u128) -> Result<Event, Error> {
+        // Guard: reject calls with insufficient value
+        if msg::value() < self.required_fee(amount) {
+            return Err(Error::InsufficientPayment);
+        }
+        // ... actual logic ...
+    }
+}
+
+impl MyService {
+    fn required_fee(&self, amount: u128) -> u128 {
+        // Percentage model:
+        amount * self.fee_bps / 10_000
+        // Or flat:
+        // self.flat_fee
     }
 }
 ```
 
 ### Refund on error
 
-If the method fails after the value check, refund the user's value:
+If the method fails after the value check, refund:
 
 ```rust
-if msg::value() < MIN_CHARGE {
-    return Err(Error::InsufficientPayment);
-}
-
 match self.internal_logic() {
     Ok(event) => Ok(event),
     Err(e) => {
-        // Refund — user paid but operation failed
-        msg::reply_bytes(e.encode(), msg::value())?;
+        msg::reply_bytes(e.encode(), msg::value())?; // refund
         Err(e)
     }
 }
 ```
 
-This builds trust: users only pay for successful operations.
+### Making fees configurable
 
-### Tiered pricing
-
-For dapps with multiple services, vary the minimum by method:
-
-```rust
-const LIGHT_CHARGE: u128 = 100_000_000_000_000; // 0.1 VARA
-const STANDARD_CHARGE: u128 = 1_000_000_000_000_000; // 1 VARA
-const HEAVY_CHARGE: u128 = 5_000_000_000_000_000; // 5 VARA
-```
-
-## Context: gas vs value
-
-| | Gas | Value |
-|---|---|---|
-| **What it pays for** | Computation (execution, storage) | The dapp's service |
-| **Who sets the price** | Network (protocol parameter) | Program author |
-| **Covered by vouchers?** | Yes (auto-renew from network backend) | No |
-| **Unit** | Gas units → converted to VARA via `gas_price` | VARA directly (`msg::value()`) |
-| **Typical cost per call** | ~0.01–0.1 VARA | 0–50 VARA (your choice) |
-
-**Key insight:** Vouchers handle gas — your program always has fuel. Value is separate and entirely under your control.
-
-## When not to charge
-
-Some dapps are better free:
-
-- **Public goods** — registries, oracles, infrastructure that benefits the ecosystem
-- **Protocol-level services** — if every agent on the network needs your service, charging may hinder adoption
-- **Early bootstrap** — start free, add pricing later when usage justifies it
-
-You can always add pricing in a program upgrade. Starting free is safer than starting too expensive.
-
-## Adjusting rates post-launch
-
-Rates are hardcoded constants in your program. To change them:
-
-1. Update the `MIN_CHARGE` (or tiered constants) in your code
-2. Rebuild and redeploy
-3. Point the Agent Network registration to the new program ID
-
-Or make rates configurable from the start with a setter guarded by an admin check:
+Don't hardcode fees. Let the operator adjust them without redeploying:
 
 ```rust
 #[sails(export)]
 impl MyService {
-    pub fn set_min_charge(&mut self, new_charge: u128) -> Result<(), Error> {
+    pub fn set_fee_bps(&mut self, new_bps: u128) -> Result<(), Error> {
         if msg::source() != self.admin {
             return Err(Error::NotAuthorized);
         }
-        self.min_charge = new_charge;
+        self.fee_bps = new_bps;
         Ok(())
     }
 }
 ```
+
+## When to stay free
+
+Some dapps are better without fees:
+
+- **Public goods** — registries, oracles, infrastructure that benefits the whole network
+- **Network utilities** — chat relays, discovery services, coordination primitives
+- **Early bootstrap** — start free, add fees when you have users who value the service
+- **Commodity services** — if ten agents offer the same thing, the market price trends to zero anyway
+
+Gas vouchers make free operation sustainable — your program always has fuel. The decision to charge is about signaling and filtering, not survival.
+
+## Is charging per action a good strategy?
+
+**Sometimes. Not always.** 
+
+Flat per-action pricing works when every action delivers uniform value:
+- Randomness oracle: every `get_random()` call returns the same quality of randomness
+- Identity attestation: every `attest()` call produces the same kind of proof
+- Name resolution: every `resolve()` call returns the same kind of answer
+
+It works poorly when value varies:
+- Swaps: a $10 swap and a $10,000 swap pay the same flat fee — unfair to small users
+- Bounties: a 10 VARA bounty and a 10,000 VARA bounty pay the same flat fee — leaves money on the table
+- Escrow: the fee should scale with the amount held, not the number of `deposit()` calls
+
+**The acid test:** If you'd feel wrong charging the same fee for two very different uses of your dapp, you need a percentage or outcome-based model instead.
 
 ## Real numbers
 
@@ -135,4 +231,4 @@ impl MyService {
 | 100 VARA in USD | ~$0.065 |
 | 1,000 VARA in USD | ~$0.65 |
 
-At these prices, a dapp charging 1 VARA/call needs ~1,540 calls to earn $1. Pricing is anti-spam, not a revenue engine — unless VARA appreciates or you reach massive scale.
+At these prices: pricing is signaling, not revenue. Unless VARA appreciates or you hit massive scale, your dapp's fees won't pay the rent. That's fine — the point of charging today is to build the habit and the infrastructure for when it matters.

--- a/agent-starter/references/pricing.md
+++ b/agent-starter/references/pricing.md
@@ -1,12 +1,12 @@
 # Pricing Guidance for Sails Programs on Vara
 
-How to set `msg::value()` minimums in agent-built dapps. These are build-time conventions — the network doesn't enforce or check them.
+How to set `msg::value()` in agent-built dapps. These are build-time conventions — the network doesn't enforce or check them.
 
 **The question isn't "how much per call?" — it's "what value does the user get?"**
 
 ## Gas covers computation. Your fee covers the outcome.
 
-Gas already pays validators for executing your program. Charging users again for the same computation is double-billing. Instead, charge for what the user actually receives:
+Gas already pays validators for executing your program. Charging users again for the same computation is double-billing. Instead, charge for what the user actually receives. Pick the row that matches:
 
 | The user wants to... | The value is... | Fee model |
 |---|---|---|
@@ -18,122 +18,29 @@ Gas already pays validators for executing your program. Charging users again for
 | Monitor a data feed | Ongoing access to updates | **Subscription (time-based)** |
 | Send a chat message | Nothing — it's network utility | **Free** |
 
-This isn't theory. Every successful dapp uses one of these models:
+Common dapp pricing follows value: AMMs and lending protocols use percentage fees, oracles use flat request fees, names/subscriptions use time-based fees. None price by "number of storage writes."
 
-- **Uniswap** charges 0.01%–1% per swap (percentage of value). Not 0.0005 ETH per call.
-- **Chainlink oracles** charge per data request (flat fee). Uniform value per use.
-- **ENS** charges $5–$640/year for domain registration (time-based subscription).
-- **Jupiter** charges 0.06% on position open/close (percentage).
-- **Polymarket** keeps most markets free; charges 0.1% taker fee on select markets only.
-- **Aave** charges a percentage of borrow amount, not per `borrow()` call.
+## Why charge at all
 
-None of them charge "per state change."
+Gas is near-zero on Vara and covered by vouchers. Your fee does two things gas doesn't:
 
-## Two things gas doesn't do
+1. **Quality anchoring.** A program that charges 0 signals "toy." A non-zero charge signals "this is built to last."
+2. **User commitment.** Free services attract noise. A small charge filters out bots and tire-kickers.
 
-If gas already covers execution, what's left for your fee?
-
-1. **Quality anchoring.** A program that charges 0 signals "toy." A program that charges something — even a trivial amount — signals "this is built to last."
-2. **User commitment.** Free services attract noise. A small charge filters out bots and tire-kickers. The user who pays 1 VARA to attest their identity values the attestation.
-
-**At current VARA prices, neither of these is about revenue.** VARA trades at ~$0.00065. You'd need ~1,540 calls at 1 VARA to earn $1. Pricing on Vara today is signaling, not income.
+Pricing on Vara today is signaling, not income. Token prices are volatile — treat fees as spam resistance and quality marking unless usage or price changes materially.
 
 ## How to choose a model
 
-Start with the outcome, not the code path:
+**The acid test:** if you'd feel wrong charging the same fee for two very different uses of your dapp, use percentage or outcome-based pricing instead of flat.
 
-```
-What does the user GET?
-    │
-    ├─ Value proportional to an amount ──→ Percentage fee (e.g., 0.5% of swap/bounty)
-    │
-    ├─ Uniform value every time ─────────→ Flat fee per use (e.g., 1 VARA per random number)
-    │
-    ├─ Ongoing access over time ─────────→ Time-based (e.g., 10 VARA/month subscription)
-    │
-    ├─ One-time permanent record ────────→ Flat fee, operator-set (e.g., 50 VARA registration)
-    │
-    └─ Network utility / public good ────→ Free. Let vouchers handle gas.
-```
+| Model | When | Formula |
+|---|---|---|
+| **Percentage** | Value scales with amount (swaps, bounties, escrow) | `fee = amount * bps / 10_000` |
+| **Flat per-use** | Uniform value every time (randomness, attestation) | `require msg::value() >= flat_fee` |
+| **Subscription** | Ongoing access over time (data feeds, memberships) | `require period fee, extend expiry` |
+| **Free** | Network utility or public good | Let vouchers handle gas |
 
-### Percentage-based fee
-
-When the value scales with an amount (swap size, bounty reward, escrow), take a cut:
-
-```rust
-const FEE_BASIS_POINTS: u128 = 50; // 0.5%
-
-#[sails(export)]
-impl MyService {
-    pub fn create_bounty(&mut self, amount: u128, description: String) -> Result<Event, Error> {
-        // User sends amount + fee. Fee is proportional to value.
-        let fee = amount * FEE_BASIS_POINTS / 10_000;
-        if msg::value() < amount + fee {
-            return Err(Error::InsufficientPayment);
-        }
-
-        // amount goes to the bounty pool, fee stays with the program
-        self.bounty_pool += amount;
-        self.collected_fees += fee;
-
-        Ok(Event::BountyCreated { amount, description })
-    }
-}
-```
-
-This is the same model Uniswap, Jupiter, and Aave use. The fee scales with usage — heavy users pay more, casual users pay less.
-
-### Flat per-use fee
-
-When every use provides the same value (randomness, attestation, name resolution), charge a fixed amount:
-
-```rust
-const ATTESTATION_FEE: u128 = 1_000_000_000_000; // 1 VARA
-
-#[sails(export)]
-impl MyService {
-    pub fn attest(&mut self, subject: ActorId, claim: String) -> Result<Event, Error> {
-        if msg::value() < ATTESTATION_FEE {
-            return Err(Error::InsufficientPayment);
-        }
-        // ... issue attestation ...
-    }
-}
-```
-
-This is the Chainlink model. The value is uniform — a random number is a random number whether you're using it for a game or a lottery.
-
-### Time-based (subscription)
-
-When value is ongoing access, charge per period:
-
-```rust
-const MONTHLY_FEE: u128 = 10_000_000_000_000; // 10 VARA
-const MS_PER_MONTH: u64 = 30 * 24 * 60 * 60 * 1000; // block_timestamp() is in ms
-
-#[sails(export)]
-impl MyService {
-    pub fn subscribe(&mut self) -> Result<Event, Error> {
-        if msg::value() < MONTHLY_FEE {
-            return Err(Error::InsufficientPayment);
-        }
-        let expiry = exec::block_timestamp() + MS_PER_MONTH;
-        self.subscribers.insert(msg::source(), expiry);
-        Ok(Event::Subscribed { until: expiry })
-    }
-}
-```
-
-This is the ENS model. Users pay once for a period of access, not per call.
-
-### The anti-spam floor
-
-For services that choose flat fees, 1 VARA is a reasonable floor on Vara:
-- It matches the existential deposit — a psychologically clean number
-- At $0.00065, it's negligible for real users but non-zero cost for bots
-- It's the minimum value `vara-wallet` displays cleanly by default
-
-**Do not charge less than 0.1 VARA.** Below that, the anti-spam effect vanishes and you're just adding complexity for no benefit.
+For flat fees, 1 VARA is a reasonable floor — it matches the existential deposit. Don't charge less than 0.1 VARA; below that the anti-spam effect vanishes.
 
 ## Implementation patterns
 
@@ -143,7 +50,6 @@ For services that choose flat fees, 1 VARA is a reasonable floor on Vara:
 #[sails(export)]
 impl MyService {
     pub fn do_something(&mut self, amount: u128) -> Result<Event, Error> {
-        // Guard: reject calls with insufficient value
         if msg::value() < self.required_fee(amount) {
             return Err(Error::InsufficientPayment);
         }
@@ -153,103 +59,42 @@ impl MyService {
 
 impl MyService {
     fn required_fee(&self, amount: u128) -> u128 {
-        // Percentage model:
-        amount * self.fee_bps / 10_000
-        // Or flat:
-        // self.flat_fee
+        // Percentage: amount * self.fee_bps / 10_000
+        // Flat:      self.flat_fee
     }
 }
 ```
 
 ### Handling errors without losing user funds
 
-When a call attaches `msg::value()`, those tokens are transferred to your program at execution start — regardless of whether you return `Ok` or `Err`. Returning `Err` does NOT automatically refund the value. If your method fails after receiving payment, you must explicitly send the value back:
+When a call attaches `msg::value()`, those tokens transfer to your program at execution start — regardless of whether you return `Ok` or `Err`. Returning `Err` does **not** automatically refund the value. You must explicitly send it back on failure:
 
 ```rust
-#[sails(export)]
-impl MyService {
-    pub fn do_something(&mut self, amount: u128) -> Result<Event, Error> {
-        // Step 1: Validate payment
-        let fee = self.required_fee(amount);
-        if msg::value() < fee {
-            return Err(Error::InsufficientPayment);
-        }
-
-        // Step 2: Do the work
-        match self.internal_logic(amount) {
-            Ok(result) => {
-                // Success — keep the fee
-                self.collected_fees += fee;
-                Ok(Event::Done { result })
-            }
-            Err(e) => {
-                // Failed — refund the user's full value
-                // Unwrap is safe: send to source never fails
-                sails_rs::gstd::msg::send(msg::source(), b"refund", msg::value())
-                    .expect("refund send failed");
-                Err(e)
-            }
-        }
+match self.internal_logic(amount) {
+    Ok(result) => {
+        self.collected_fees += fee;
+        Ok(Event::Done { result })
+    }
+    Err(e) => {
+        // Refund the user's value on failure
+        sails_rs::gstd::msg::send(msg::source(), b"refund", msg::value())
+            .expect("refund send failed");
+        Err(e)
     }
 }
 ```
 
-**Without this refund, failed calls keep user funds.** This is the same model as Ethereum: gas is spent regardless, but the payment value must be explicitly returned on failure. On Vara, gas vouchers make failed attempts cheap — the user only loses gas, not the fee.
-
-### Making fees configurable
-
-Don't hardcode fees. Let the operator adjust them without redeploying:
-
-```rust
-#[sails(export)]
-impl MyService {
-    pub fn set_fee_bps(&mut self, new_bps: u128) -> Result<(), Error> {
-        if msg::source() != self.admin {
-            return Err(Error::NotAuthorized);
-        }
-        self.fee_bps = new_bps;
-        Ok(())
-    }
-}
-```
+Prefer operator-configurable fees over hardcoded constants once the dapp has real users.
 
 ## When to stay free
-
-Some dapps are better without fees:
 
 - **Public goods** — registries, oracles, infrastructure that benefits the whole network
 - **Network utilities** — chat relays, discovery services, coordination primitives
 - **Early bootstrap** — start free, add fees when you have users who value the service
-- **Commodity services** — if ten agents offer the same thing, the market price trends to zero anyway
+- **Commodity services** — if ten agents offer the same thing, the market price trends to zero
 
-Gas vouchers make free operation sustainable — your program always has fuel. The decision to charge is about signaling and filtering, not survival.
-
-## Is charging per action a good strategy?
-
-**Sometimes. Not always.** 
-
-Flat per-action pricing works when every action delivers uniform value:
-- Randomness oracle: every `get_random()` call returns the same quality of randomness
-- Identity attestation: every `attest()` call produces the same kind of proof
-- Name resolution: every `resolve()` call returns the same kind of answer
-
-It works poorly when value varies:
-- Swaps: a $10 swap and a $10,000 swap pay the same flat fee — unfair to small users
-- Bounties: a 10 VARA bounty and a 10,000 VARA bounty pay the same flat fee — leaves money on the table
-- Escrow: the fee should scale with the amount held, not the number of `deposit()` calls
-
-**The acid test:** If you'd feel wrong charging the same fee for two very different uses of your dapp, you need a percentage or outcome-based model instead.
+Gas vouchers make free operation sustainable. The decision to charge is about signaling and filtering, not survival.
 
 ## Real numbers
 
-*As of May 2026. Token prices are volatile — check current rates before deciding.*
-
-| Metric | Value |
-|---|---|
-| VARA price (USD) | ~$0.00065 |
-| 1 VARA in plancks | 1,000,000,000,000 |
-| 10 VARA in USD | ~$0.0065 |
-| 100 VARA in USD | ~$0.065 |
-| 1,000 VARA in USD | ~$0.65 |
-
-At these prices: pricing is signaling, not revenue. Unless VARA appreciates or you hit massive scale, your dapp's fees won't pay the rent. That's fine — the point of charging today is to build the habit and the infrastructure for when it matters.
+1 VARA = 1,000,000,000,000 plancks. Token prices move — treat current fees as signaling and spam resistance. Unless VARA appreciates or you hit massive scale, dapp fees won't pay the rent. That's fine — the point of charging today is to build the habit and infrastructure for when it matters.

--- a/agent-starter/templates/sails-program-layout/lib.rs
+++ b/agent-starter/templates/sails-program-layout/lib.rs
@@ -30,6 +30,9 @@ compile_error!(
 //      should appear in the IDL.
 //   7. `#[cfg(test)]` module — calls the pure helpers, never the exported
 //      `#[export]` methods (those are async PendingCalls under the hood).
+//   8. Pricing — if your service charges users, add a `msg::value()` guard
+//      at the top of each `#[export]` method. See `references/pricing.md` for
+//      recommended minimums and the refund-on-error pattern.
 
 #![no_std]
 


### PR DESCRIPTION
## What

Research-backed `references/pricing.md` for the agent-starter skill pack, plus three light-touch micropayment hints in `STARTER_PROMPT.md` and four cross-links.

Closes #16.

## The question this answers

**"Is charging actual VARA per action a good strategy?"**

Answer: sometimes yes, sometimes no. The doc teaches agents to pick a pricing model based on the *value the user receives*, not the computation consumed. Gas already covers execution — your fee covers the outcome.

## references/pricing.md

Four value-based pricing models with real-world examples:

| Model | When | Examples |
|---|---|---|
| **Percentage** | Value proportional to amount | Uniswap 0.3%, Jupiter 0.06%, Aave |
| **Flat per-use** | Uniform value every time | Chainlink oracles, identity attestation |
| **Subscription** | Ongoing access over time | ENS $5-640/year |
| **Free** | Network utility / public good | Polymarket most markets |

Includes:
- Acid test: "if you'd feel wrong charging the same fee for two very different uses, you need percentage-based, not flat"
- Rust patterns for each model (percentage calc, flat guard, subscription expiry)
- Refund-on-error, admin-configurable fees
- Anti-spam floor (0.1-1 VARA) framed as signaling, not revenue
- "When to stay free" — gas vouchers make free operation sustainable
- Real numbers table with current VARA/USD

## STARTER_PROMPT hints

Three one-sentence nudges across the dapp lifecycle:
1. **Brainstorm:** "Should users pay for this service?"
2. **Build:** `msg::value()` check with gas/value distinction
3. **Handoff:** "Add micropayments" menu option

## Cross-links (4 total)

| File | Change |
|---|---|
| `lint.sh` | Adds `references/pricing.md` to REQUIRED_FILES |
| `templates/sails-program-layout/lib.rs` | Annotated comment |
| `agent-onboarding.md` | New row in routing table |
| `STARTER_PROMPT.md` | Seeded with hints from this PR |

## Version

1.1.0 → 1.1.1
