### PR TITLE
Initial version of seed-backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .code-review-graph/
 target/
 node_modules/
+services/seed-backend/lib/
 .env
 .env.local
 .env.development.local

--- a/services/seed-backend/.env.example
+++ b/services/seed-backend/.env.example
@@ -17,9 +17,6 @@ API_CORS_ORIGIN=http://localhost:3000,http://localhost:5173
 # Required when NODE_ENV=production.
 SEED_API_KEY=
 
-# Eligibility/status policy
-ELIGIBLE_STATUSES=Submitted,Live,Finalist,Winner
-
 # Economics. Defaults match the current hackathon policy:
 # - top up new eligible wallets toward 10 VARA
 # - allow at most 100 VARA/day per wallet across all owned applications

--- a/services/seed-backend/.env.example
+++ b/services/seed-backend/.env.example
@@ -14,26 +14,40 @@ PORT=3002
 API_CORS_ORIGIN=http://localhost:3000,http://localhost:5173
 
 # Optional API key for mutating endpoints. Leave empty for internal/dev deploys.
+# Required when NODE_ENV=production.
 SEED_API_KEY=
 
 # Eligibility/status policy
 ELIGIBLE_STATUSES=Submitted,Live,Finalist,Winner
 
-# Economics
+# Economics. Defaults match the current hackathon policy:
+# - top up new eligible wallets toward 10 VARA
+# - allow at most 100 VARA/day per wallet across all owned applications
+# - allow at most 1000 VARA/day globally across this backend
+# - refill toward 10 VARA once per day when risk is clean
 VARA_DECIMALS=12
 INITIAL_TARGET_VARA=10
 MAX_DAILY_REFILL_VARA=100
+GLOBAL_DAILY_PAYOUT_LIMIT_VARA=1000
+LIFETIME_CAP_APP_VARA=100
+LIFETIME_CAP_WALLET_VARA=300
+LIFETIME_CAP_GITHUB_VARA=300
+LIFETIME_CAP_REPO_VARA=100
 REFILL_TARGET_VARA=10
-MIN_REFILL_INTERVAL_SEC=3600
+MIN_REFILL_INTERVAL_SEC=86400
 
 # Risk policy
 SUSPICIOUS_PAUSE_THRESHOLD_VARA=5
 BLACKLIST_THRESHOLD=3
 
 # Monitoring
-MONITOR_START_BLOCK=0
+# Use "latest" by default so a fresh production deploy does not scan from block 0.
+# Set an explicit archive-backed block number when you need historical backfill.
+MONITOR_START_BLOCK=latest
 MONITOR_POLL_INTERVAL_MS=6000
 
 # GitHub validation
 GITHUB_TOKEN=
 RECENT_COMMIT_DAYS=45
+GITHUB_VALIDATION_TTL_SEC=86400
+MIN_REFILL_ACTIVITY_EVENTS=1

--- a/services/seed-backend/.env.example
+++ b/services/seed-backend/.env.example
@@ -1,0 +1,39 @@
+# Vara RPC node. Use an archive endpoint in production so monitoring can resume
+# from the stored cursor without losing transfer history.
+VARA_RPC_URL=wss://testnet.vara.network
+
+# Seed treasury account (seed phrase, hex seed, or //Alice for dev).
+# This account sends real liquid VARA to eligible agent wallets.
+SEED_ACCOUNT=//Alice
+
+# Database. Can point to the same Postgres database used by services/indexer.
+DATABASE_URL=postgres://indexer:indexer@localhost:5433/indexer
+
+# Server
+PORT=3002
+API_CORS_ORIGIN=http://localhost:3000,http://localhost:5173
+
+# Optional API key for mutating endpoints. Leave empty for internal/dev deploys.
+SEED_API_KEY=
+
+# Eligibility/status policy
+ELIGIBLE_STATUSES=Submitted,Live,Finalist,Winner
+
+# Economics
+VARA_DECIMALS=12
+INITIAL_TARGET_VARA=10
+MAX_DAILY_REFILL_VARA=100
+REFILL_TARGET_VARA=10
+MIN_REFILL_INTERVAL_SEC=3600
+
+# Risk policy
+SUSPICIOUS_PAUSE_THRESHOLD_VARA=5
+BLACKLIST_THRESHOLD=3
+
+# Monitoring
+MONITOR_START_BLOCK=0
+MONITOR_POLL_INTERVAL_MS=6000
+
+# GitHub validation
+GITHUB_TOKEN=
+RECENT_COMMIT_DAYS=45

--- a/services/seed-backend/.env.example
+++ b/services/seed-backend/.env.example
@@ -1,6 +1,6 @@
 # Vara RPC node. Use an archive endpoint in production so monitoring can resume
 # from the stored cursor without losing transfer history.
-VARA_RPC_URL=wss://testnet.vara.network
+VARA_RPC_URL=wss://testnet-archive.vara.network
 
 # Seed treasury account (seed phrase, hex seed, or //Alice for dev).
 # This account sends real liquid VARA to eligible agent wallets.
@@ -8,6 +8,9 @@ SEED_ACCOUNT=//Alice
 
 # Database. Can point to the same Postgres database used by services/indexer.
 DATABASE_URL=postgres://indexer:indexer@localhost:5433/indexer
+# Set false in production after running `npm run build && npm run migrate`
+# with a migration role. The runtime service will then only validate schema.
+SEED_AUTO_MIGRATE=true
 
 # Server
 PORT=3002
@@ -18,23 +21,25 @@ API_CORS_ORIGIN=http://localhost:3000,http://localhost:5173
 SEED_API_KEY=
 
 # Economics. Defaults match the current hackathon policy:
-# - top up new eligible wallets toward 5 VARA
-# - allow at most 10 VARA/day per wallet across all owned applications
-# - allow at most 100 VARA/day globally across this backend
-# - refill toward 5 VARA once per day when risk is clean
+# - top up new eligible wallets toward 500 VARA
+# - refill toward 2000 VARA once per day when risk/activity is clean
+# - cap each app/repo at 2000 VARA lifetime
+# - allow up to five funded apps per wallet/GitHub owner by default
+# - set REFILL_TRIGGER_BALANCE_VARA > 0 to refill only below that balance
 VARA_DECIMALS=12
-INITIAL_TARGET_VARA=5
-MAX_DAILY_REFILL_VARA=10
-GLOBAL_DAILY_PAYOUT_LIMIT_VARA=100
-LIFETIME_CAP_APP_VARA=25
-LIFETIME_CAP_WALLET_VARA=50
-LIFETIME_CAP_GITHUB_VARA=50
-LIFETIME_CAP_REPO_VARA=25
-REFILL_TARGET_VARA=5
+INITIAL_TARGET_VARA=500
+MAX_DAILY_REFILL_VARA=2000
+GLOBAL_DAILY_PAYOUT_LIMIT_VARA=100000
+LIFETIME_CAP_APP_VARA=2000
+LIFETIME_CAP_WALLET_VARA=10000
+LIFETIME_CAP_GITHUB_VARA=10000
+LIFETIME_CAP_REPO_VARA=2000
+REFILL_TARGET_VARA=2000
+REFILL_TRIGGER_BALANCE_VARA=0
 MIN_REFILL_INTERVAL_SEC=86400
 
 # Risk policy
-SUSPICIOUS_PAUSE_THRESHOLD_VARA=3
+SUSPICIOUS_PAUSE_THRESHOLD_VARA=10
 # Number of suspicious outgoing spends after which the wallet/app is blacklisted.
 BLACKLIST_THRESHOLD=2
 
@@ -45,7 +50,21 @@ MONITOR_START_BLOCK=latest
 MONITOR_POLL_INTERVAL_MS=6000
 
 # GitHub validation
+# Required when NODE_ENV=production.
 GITHUB_TOKEN=
-RECENT_COMMIT_DAYS=45
+RECENT_COMMIT_DAYS=15
 GITHUB_VALIDATION_TTL_SEC=86400
 MIN_REFILL_ACTIVITY_EVENTS=1
+
+# Optional public indexer GraphQL sync. When set, the backend mirrors registered
+# applications into the local Postgres on startup and on the interval below.
+# Keep APPLICATION_SYNC_ENABLED=false when DATABASE_URL points at the indexer DB.
+APPLICATION_SYNC_ENABLED=false
+INDEXER_GRAPHQL_URL=
+APPLICATION_SYNC_INTERVAL_SEC=300
+
+# Automatic payout scans. AUTO_CLAIM_INTERVAL_SEC funds unfunded registered
+# applications with the initial 500 VARA top-up. AUTO_REFILL_INTERVAL_SEC
+# refills already funded active allocations toward REFILL_TARGET_VARA.
+AUTO_CLAIM_INTERVAL_SEC=60
+AUTO_REFILL_INTERVAL_SEC=300

--- a/services/seed-backend/.env.example
+++ b/services/seed-backend/.env.example
@@ -18,24 +18,25 @@ API_CORS_ORIGIN=http://localhost:3000,http://localhost:5173
 SEED_API_KEY=
 
 # Economics. Defaults match the current hackathon policy:
-# - top up new eligible wallets toward 10 VARA
-# - allow at most 100 VARA/day per wallet across all owned applications
-# - allow at most 1000 VARA/day globally across this backend
-# - refill toward 10 VARA once per day when risk is clean
+# - top up new eligible wallets toward 5 VARA
+# - allow at most 10 VARA/day per wallet across all owned applications
+# - allow at most 100 VARA/day globally across this backend
+# - refill toward 5 VARA once per day when risk is clean
 VARA_DECIMALS=12
-INITIAL_TARGET_VARA=10
-MAX_DAILY_REFILL_VARA=100
-GLOBAL_DAILY_PAYOUT_LIMIT_VARA=1000
-LIFETIME_CAP_APP_VARA=100
-LIFETIME_CAP_WALLET_VARA=300
-LIFETIME_CAP_GITHUB_VARA=300
-LIFETIME_CAP_REPO_VARA=100
-REFILL_TARGET_VARA=10
+INITIAL_TARGET_VARA=5
+MAX_DAILY_REFILL_VARA=10
+GLOBAL_DAILY_PAYOUT_LIMIT_VARA=100
+LIFETIME_CAP_APP_VARA=25
+LIFETIME_CAP_WALLET_VARA=50
+LIFETIME_CAP_GITHUB_VARA=50
+LIFETIME_CAP_REPO_VARA=25
+REFILL_TARGET_VARA=5
 MIN_REFILL_INTERVAL_SEC=86400
 
 # Risk policy
-SUSPICIOUS_PAUSE_THRESHOLD_VARA=5
-BLACKLIST_THRESHOLD=3
+SUSPICIOUS_PAUSE_THRESHOLD_VARA=3
+# Number of suspicious outgoing spends after which the wallet/app is blacklisted.
+BLACKLIST_THRESHOLD=2
 
 # Monitoring
 # Use "latest" by default so a fresh production deploy does not scan from block 0.

--- a/services/seed-backend/Dockerfile
+++ b/services/seed-backend/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json package-lock.json tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/lib ./lib
+EXPOSE 3002
+CMD ["node", "lib/main.js"]

--- a/services/seed-backend/Dockerfile
+++ b/services/seed-backend/Dockerfile
@@ -16,5 +16,6 @@ ENV NODE_ENV=production
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/lib ./lib
+COPY migrations ./migrations
 EXPOSE 3002
 CMD ["node", "lib/main.js"]

--- a/services/seed-backend/README.md
+++ b/services/seed-backend/README.md
@@ -9,8 +9,8 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
 - Uses `applications.owner` as the agent wallet.
 - Funds registered applications regardless of status.
 - Validates GitHub repository quality before first funding.
-- Sends an initial top-up toward `INITIAL_TARGET_VARA` (`10` by default).
-- Allows later refills up to `MAX_DAILY_REFILL_VARA` (`100` by default) per wallet when risk is clean.
+- Sends an initial top-up toward `INITIAL_TARGET_VARA` (`5` in `.env.example`).
+- Allows later refills up to `MAX_DAILY_REFILL_VARA` (`10` in `.env.example`) per wallet when risk is clean.
 - Enforces lifetime caps per app, wallet, GitHub owner, and GitHub repo.
 - Reserves payouts as `PENDING` before sending and marks them `SENT` only after the transfer lands.
 - Enforces `GLOBAL_DAILY_PAYOUT_LIMIT_VARA` across all payouts from the service.

--- a/services/seed-backend/README.md
+++ b/services/seed-backend/README.md
@@ -6,11 +6,18 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
 ## What It Does
 
 - Reads eligible applications from the indexer `applications` table.
+- In production, should point at the same Postgres database as the indexer and
+  read `applications`/`interactions` directly.
+- Can mirror registered applications from `INDEXER_GRAPHQL_URL` into local
+  Postgres only for standalone local testing.
 - Uses `applications.owner` as the agent wallet.
 - Funds registered applications regardless of status.
 - Validates GitHub repository quality before first funding.
-- Sends an initial top-up toward `INITIAL_TARGET_VARA` (`5` in `.env.example`).
-- Allows later refills up to `MAX_DAILY_REFILL_VARA` (`10` in `.env.example`) per wallet when risk is clean.
+- Sends an initial top-up toward `INITIAL_TARGET_VARA` (`500` in `.env.example`).
+- Can automatically claim unfunded registered applications when
+  `AUTO_CLAIM_INTERVAL_SEC > 0`.
+- Allows later refills toward `REFILL_TARGET_VARA` (`2000` in `.env.example`) when risk/activity is clean.
+- `REFILL_TRIGGER_BALANCE_VARA` can require the wallet to drop below a threshold before refill.
 - Enforces lifetime caps per app, wallet, GitHub owner, and GitHub repo.
 - Reserves payouts as `PENDING` before sending and marks them `SENT` only after the transfer lands.
 - Enforces `GLOBAL_DAILY_PAYOUT_LIMIT_VARA` across all payouts from the service.
@@ -21,6 +28,11 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
   - `gear.sendMessage` calls with non-zero attached value.
 - Allows spending to any registered application program ID, regardless of
   status, and pauses/blacklists wallets that spend seed funds elsewhere.
+- A paused or blacklisted wallet cannot bypass the block by registering another
+  application; new allocations inherit the wallet's most restrictive state.
+- Tracks registered programs that receive seed-derived value and treats
+  `gear.UserMessageSent` value transfers from those programs to external
+  wallets as suspicious spend for the original funded wallet.
 
 ## API
 
@@ -31,15 +43,19 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
 - `POST /seed/claim` with `{ "applicationId": "0x..." }`
 - `POST /seed/refill` with `{ "applicationId": "0x..." }`
 - `POST /seed/scan` scans eligible applications and funds those that pass.
+- `POST /seed/sync-applications` mirrors applications from the configured indexer GraphQL API.
+- `POST /seed/refill-scan` runs one scheduled-refill pass over active funded allocations.
 - `POST /seed/payouts/:idempotencyKey/mark-sent` with `{ "txHash": "0x..." }`
 - `POST /seed/payouts/:idempotencyKey/cancel` with `{ "reason": "..." }`
+- `POST /seed/allocations/:wallet/unblacklist` with `{ "reason": "..." }`
 
 Cancelling a `PENDING` payout means the transfer is confirmed not to have been
 sent. The next payout attempt for the same scope gets a new `:attempt-N`
 idempotency key. Existing `PENDING` or `SENT` payouts still block retries.
 
 Mutating endpoints require `Authorization: Bearer $SEED_API_KEY` when
-`SEED_API_KEY` is set. In production, `SEED_API_KEY` is required at boot.
+`SEED_API_KEY` is set. In production, `SEED_API_KEY` and `GITHUB_TOKEN` are
+required at boot.
 Allocation and payout listing endpoints are admin/debug data and use the same
 API key guard.
 
@@ -48,9 +64,50 @@ API key guard.
 ```bash
 npm install
 npm run build
+npm run migrate
 npm start
 ```
+
+## Shared Indexer Database
+
+Production should use the indexer's existing Postgres database instead of a
+separate seed database. The current implementation expects both indexer tables
+and seed tables to be available through the connection's default schema
+(`public` in the indexer deployment):
+
+```env
+DATABASE_URL=postgres://seed_runtime:...@postgres:5432/indexer
+SEED_AUTO_MIGRATE=false
+APPLICATION_SYNC_ENABLED=false
+INDEXER_GRAPHQL_URL=
+```
+
+Apply seed migrations once before starting the runtime service:
+
+```bash
+npm run build
+DATABASE_URL=postgres://seed_migrator:...@postgres:5432/indexer npm run migrate
+```
+
+The migration creates only `seed_*` tables plus `seed_schema_migrations`; it
+does not create or mutate indexer tables. The runtime service validates that
+the indexer-owned `applications` table exists with the required columns.
+
+Recommended database permissions:
+
+- migration role: `CREATE` on the target schema and write access to `seed_*`.
+- runtime role: `SELECT` on `applications` and `interactions`; read/write on
+  `seed_*`; no write access to indexer-owned tables.
 
 By default the monitor starts at the latest finalized block on first boot.
 Use an archive RPC and set an explicit `MONITOR_START_BLOCK` when historical
 backfill is required.
+
+Set `AUTO_CLAIM_INTERVAL_SEC=60` in production if new registered applications
+should receive the initial top-up automatically. The scan also runs once on
+startup. It pays only applications that do not already have funded seed
+allocation rows.
+
+Set `AUTO_REFILL_INTERVAL_SEC=300` to automatically check active funded
+allocations for refill. Refill still respects cooldown, activity, balance
+trigger, risk state, daily caps, and lifetime caps.

--- a/services/seed-backend/README.md
+++ b/services/seed-backend/README.md
@@ -9,8 +9,13 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
 - Uses `applications.owner` as the agent wallet.
 - Funds only apps in `Submitted`, `Live`, `Finalist`, or `Winner` by default.
 - Validates GitHub repository quality before first funding.
-- Sends an initial top-up toward `INITIAL_TARGET_VARA`.
-- Allows later refills up to `MAX_DAILY_REFILL_VARA` when risk is clean.
+- Sends an initial top-up toward `INITIAL_TARGET_VARA` (`10` by default).
+- Allows later refills up to `MAX_DAILY_REFILL_VARA` (`100` by default) per wallet when risk is clean.
+- Enforces lifetime caps per app, wallet, GitHub owner, and GitHub repo.
+- Reserves payouts as `PENDING` before sending and marks them `SENT` only after the transfer lands.
+- Enforces `GLOBAL_DAILY_PAYOUT_LIMIT_VARA` across all payouts from the service.
+- Requires `MIN_REFILL_ACTIVITY_EVENTS` meaningful activity events before refill.
+- Caches successful GitHub validation for `GITHUB_VALIDATION_TTL_SEC`.
 - Monitors finalized chain blocks for:
   - `balances.Transfer` outgoing transfers from funded wallets.
   - `gear.sendMessage` calls with non-zero attached value.
@@ -22,12 +27,15 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
 - `GET /health`
 - `GET /seed/allocations`
 - `GET /seed/allocations/:wallet`
+- `GET /seed/payouts?status=PENDING`
 - `POST /seed/claim` with `{ "applicationId": "0x..." }`
 - `POST /seed/refill` with `{ "applicationId": "0x..." }`
 - `POST /seed/scan` scans eligible applications and funds those that pass.
+- `POST /seed/payouts/:idempotencyKey/mark-sent` with `{ "txHash": "0x..." }`
+- `POST /seed/payouts/:idempotencyKey/cancel` with `{ "reason": "..." }`
 
 Mutating endpoints require `Authorization: Bearer $SEED_API_KEY` when
-`SEED_API_KEY` is set.
+`SEED_API_KEY` is set. In production, `SEED_API_KEY` is required at boot.
 
 ## Run
 
@@ -37,5 +45,6 @@ npm run build
 npm start
 ```
 
-Use an archive RPC in production. Public pruned RPCs can miss old blocks when
-the monitor resumes from a stale cursor.
+By default the monitor starts at the latest finalized block on first boot.
+Use an archive RPC and set an explicit `MONITOR_START_BLOCK` when historical
+backfill is required.

--- a/services/seed-backend/README.md
+++ b/services/seed-backend/README.md
@@ -7,7 +7,7 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
 
 - Reads eligible applications from the indexer `applications` table.
 - Uses `applications.owner` as the agent wallet.
-- Funds only apps in `Submitted`, `Live`, `Finalist`, or `Winner` by default.
+- Funds registered applications regardless of status.
 - Validates GitHub repository quality before first funding.
 - Sends an initial top-up toward `INITIAL_TARGET_VARA` (`10` by default).
 - Allows later refills up to `MAX_DAILY_REFILL_VARA` (`100` by default) per wallet when risk is clean.
@@ -19,8 +19,8 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
 - Monitors finalized chain blocks for:
   - `balances.Transfer` outgoing transfers from funded wallets.
   - `gear.sendMessage` calls with non-zero attached value.
-- Pauses or blacklists wallets that spend seed funds outside registered
-  hackathon application program IDs.
+- Allows spending to any registered application program ID, regardless of
+  status, and pauses/blacklists wallets that spend seed funds elsewhere.
 
 ## API
 
@@ -34,8 +34,14 @@ backend, this service transfers real liquid VARA to eligible agent wallets.
 - `POST /seed/payouts/:idempotencyKey/mark-sent` with `{ "txHash": "0x..." }`
 - `POST /seed/payouts/:idempotencyKey/cancel` with `{ "reason": "..." }`
 
+Cancelling a `PENDING` payout means the transfer is confirmed not to have been
+sent. The next payout attempt for the same scope gets a new `:attempt-N`
+idempotency key. Existing `PENDING` or `SENT` payouts still block retries.
+
 Mutating endpoints require `Authorization: Bearer $SEED_API_KEY` when
 `SEED_API_KEY` is set. In production, `SEED_API_KEY` is required at boot.
+Allocation and payout listing endpoints are admin/debug data and use the same
+API key guard.
 
 ## Run
 

--- a/services/seed-backend/README.md
+++ b/services/seed-backend/README.md
@@ -1,0 +1,41 @@
+# VARA Seed Allocation Backend
+
+Server-managed top-up service for hackathon agents. Unlike the gas voucher
+backend, this service transfers real liquid VARA to eligible agent wallets.
+
+## What It Does
+
+- Reads eligible applications from the indexer `applications` table.
+- Uses `applications.owner` as the agent wallet.
+- Funds only apps in `Submitted`, `Live`, `Finalist`, or `Winner` by default.
+- Validates GitHub repository quality before first funding.
+- Sends an initial top-up toward `INITIAL_TARGET_VARA`.
+- Allows later refills up to `MAX_DAILY_REFILL_VARA` when risk is clean.
+- Monitors finalized chain blocks for:
+  - `balances.Transfer` outgoing transfers from funded wallets.
+  - `gear.sendMessage` calls with non-zero attached value.
+- Pauses or blacklists wallets that spend seed funds outside registered
+  hackathon application program IDs.
+
+## API
+
+- `GET /health`
+- `GET /seed/allocations`
+- `GET /seed/allocations/:wallet`
+- `POST /seed/claim` with `{ "applicationId": "0x..." }`
+- `POST /seed/refill` with `{ "applicationId": "0x..." }`
+- `POST /seed/scan` scans eligible applications and funds those that pass.
+
+Mutating endpoints require `Authorization: Bearer $SEED_API_KEY` when
+`SEED_API_KEY` is set.
+
+## Run
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+Use an archive RPC in production. Public pruned RPCs can miss old blocks when
+the monitor resumes from a stale cursor.

--- a/services/seed-backend/docker-compose.yml
+++ b/services/seed-backend/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: vara-seed-postgres
+    environment:
+      POSTGRES_USER: seed
+      POSTGRES_PASSWORD: seed
+      POSTGRES_DB: seed
+    ports:
+      - "5434:5432"
+    volumes:
+      - seed-postgres-data:/var/lib/postgresql/data
+      - ./docker/initdb:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U seed -d seed"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  seed-backend:
+    build:
+      context: .
+    container_name: vara-seed-backend
+    env_file:
+      - .env.local
+    environment:
+      DATABASE_URL: postgres://seed:seed@postgres:5432/seed
+      APPLICATION_SYNC_ENABLED: true
+      INDEXER_GRAPHQL_URL: https://agents-api.vara.network/graphql
+      NODE_ENV: development
+      PORT: 3002
+      VARA_RPC_URL: wss://testnet-archive.vara.network
+    ports:
+      - "3002:3002"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  seed-postgres-data:

--- a/services/seed-backend/docker/initdb/001_applications.sql
+++ b/services/seed-backend/docker/initdb/001_applications.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS applications (
+  id text PRIMARY KEY,
+  handle text NOT NULL,
+  owner text NOT NULL,
+  github_url text NOT NULL,
+  status text NOT NULL DEFAULT 'Building',
+  season_id integer NOT NULL DEFAULT 1,
+  registered_at bigint NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS applications_owner_idx ON applications(owner);

--- a/services/seed-backend/migrations/0001_seed_backend.sql
+++ b/services/seed-backend/migrations/0001_seed_backend.sql
@@ -1,0 +1,89 @@
+CREATE TABLE IF NOT EXISTS seed_allocations (
+  id bigserial PRIMARY KEY,
+  wallet text NOT NULL,
+  application_id text NOT NULL,
+  github_url text NOT NULL,
+  github_owner text,
+  github_repo text,
+  state text NOT NULL DEFAULT 'active',
+  total_funded_raw numeric(78,0) NOT NULL DEFAULT 0,
+  daily_funded_raw numeric(78,0) NOT NULL DEFAULT 0,
+  daily_window date NOT NULL DEFAULT CURRENT_DATE,
+  last_funded_at timestamptz,
+  suspicious_count int NOT NULL DEFAULT 0,
+  risk_score int NOT NULL DEFAULT 0,
+  last_reason text,
+  github_checked_at timestamptz,
+  github_ok boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (wallet, application_id)
+);
+
+CREATE INDEX IF NOT EXISTS seed_allocations_wallet_idx ON seed_allocations(wallet);
+CREATE INDEX IF NOT EXISTS seed_allocations_state_idx ON seed_allocations(state);
+
+CREATE TABLE IF NOT EXISTS seed_payouts (
+  idempotency_key text PRIMARY KEY,
+  status text NOT NULL,
+  wallet text NOT NULL,
+  application_id text NOT NULL,
+  github_owner text NOT NULL,
+  github_repo text NOT NULL,
+  amount_raw numeric(78,0) NOT NULL,
+  reason text NOT NULL,
+  tx_hash text,
+  error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  sent_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS seed_payouts_status_idx ON seed_payouts(status);
+CREATE INDEX IF NOT EXISTS seed_payouts_wallet_idx ON seed_payouts(wallet);
+CREATE INDEX IF NOT EXISTS seed_payouts_app_idx ON seed_payouts(application_id);
+CREATE INDEX IF NOT EXISTS seed_payouts_github_idx ON seed_payouts(github_owner);
+CREATE INDEX IF NOT EXISTS seed_payouts_repo_idx ON seed_payouts(github_owner, github_repo);
+
+CREATE TABLE IF NOT EXISTS seed_funding_events (
+  id bigserial PRIMARY KEY,
+  wallet text NOT NULL,
+  application_id text NOT NULL,
+  amount_raw numeric(78,0) NOT NULL,
+  tx_hash text,
+  reason text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS seed_spend_events (
+  id text PRIMARY KEY,
+  wallet text NOT NULL,
+  recipient text NOT NULL,
+  amount_raw numeric(78,0) NOT NULL,
+  kind text NOT NULL,
+  allowed boolean NOT NULL,
+  substrate_block_number int NOT NULL,
+  substrate_block_ts timestamptz NOT NULL,
+  extrinsic_idx int,
+  event_idx int,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS seed_spend_events_wallet_idx ON seed_spend_events(wallet);
+CREATE INDEX IF NOT EXISTS seed_spend_events_allowed_idx ON seed_spend_events(allowed);
+
+CREATE TABLE IF NOT EXISTS seed_monitor_cursor (
+  id text PRIMARY KEY,
+  last_processed_block int NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS seed_audit_events (
+  id bigserial PRIMARY KEY,
+  wallet text,
+  application_id text,
+  level text NOT NULL,
+  message text NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/seed-backend/migrations/0001_seed_backend.sql
+++ b/services/seed-backend/migrations/0001_seed_backend.sql
@@ -72,6 +72,24 @@ CREATE TABLE IF NOT EXISTS seed_spend_events (
 CREATE INDEX IF NOT EXISTS seed_spend_events_wallet_idx ON seed_spend_events(wallet);
 CREATE INDEX IF NOT EXISTS seed_spend_events_allowed_idx ON seed_spend_events(allowed);
 
+CREATE TABLE IF NOT EXISTS seed_taint_targets (
+  id bigserial PRIMARY KEY,
+  source_wallet text NOT NULL,
+  source_application_id text NOT NULL,
+  program_id text NOT NULL,
+  amount_raw numeric(78,0) NOT NULL DEFAULT 0,
+  first_seen_block int NOT NULL,
+  last_seen_block int NOT NULL,
+  last_event_id text NOT NULL,
+  state text NOT NULL DEFAULT 'active',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (source_wallet, source_application_id, program_id)
+);
+
+CREATE INDEX IF NOT EXISTS seed_taint_targets_program_idx ON seed_taint_targets(program_id);
+CREATE INDEX IF NOT EXISTS seed_taint_targets_source_wallet_idx ON seed_taint_targets(source_wallet);
+
 CREATE TABLE IF NOT EXISTS seed_monitor_cursor (
   id text PRIMARY KEY,
   last_processed_block int NOT NULL,

--- a/services/seed-backend/package-lock.json
+++ b/services/seed-backend/package-lock.json
@@ -1,0 +1,3591 @@
+{
+  "name": "@vara-agent-network/seed-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@vara-agent-network/seed-backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@polkadot/api": "^16.4.1",
+        "@polkadot/keyring": "^13.5.1",
+        "@polkadot/util": "^13.5.1",
+        "@polkadot/util-crypto": "^13.5.1",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.7",
+        "express": "^4.21.2",
+        "pg": "^8.13.1"
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
+        "@types/node": "^22.13.1",
+        "@types/pg": "^8.11.11",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/observable-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      },
+      "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.1.0",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot/api": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
+      "integrity": "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/api-derive": "16.5.6",
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/types-known": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.6.tgz",
+      "integrity": "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
+      "integrity": "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.6.tgz",
+      "integrity": "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "16.5.6",
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api/node_modules/@polkadot/keyring": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/api/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/api/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/api/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.5.9.tgz",
+      "integrity": "sha512-bMCpHDN7U8ytxawjBZ89/he5s3AmEZuOdkM/ABcorh/flXNPfyghjFK27Gy4OKoFxX52yJ2sTHR4NxM87GuFXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "13.5.9",
+        "@polkadot/util-crypto": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.5.9",
+        "@polkadot/util-crypto": "13.5.9"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
+      "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/networks/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/networks/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/networks/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.6.tgz",
+      "integrity": "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
+      "integrity": "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.6.tgz",
+      "integrity": "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-support": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "@polkadot/x-fetch": "^14.0.3",
+        "@polkadot/x-global": "^14.0.3",
+        "@polkadot/x-ws": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.11"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.6.tgz",
+      "integrity": "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.6.tgz",
+      "integrity": "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
+      "integrity": "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/x-bigint": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
+      "integrity": "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.6.tgz",
+      "integrity": "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/networks": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
+      "integrity": "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
+      "integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "13.5.9",
+        "@polkadot/x-global": "13.5.9",
+        "@polkadot/x-textdecoder": "13.5.9",
+        "@polkadot/x-textencoder": "13.5.9",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.5.9.tgz",
+      "integrity": "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "13.5.9",
+        "@polkadot/util": "13.5.9",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "13.5.9",
+        "@polkadot/x-randomvalues": "13.5.9",
+        "@scure/base": "^1.1.7",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.5.9"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/networks": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.9.tgz",
+      "integrity": "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "13.5.9",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
+      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util/node_modules/@polkadot/x-bigint": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
+      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
+      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
+      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-init": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
+      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
+      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
+      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
+      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
+      "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
+      "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
+      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.9.tgz",
+      "integrity": "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.5.9",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.9.tgz",
+      "integrity": "sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.9.tgz",
+      "integrity": "sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
+      "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
+      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.2",
+        "@noble/hashes": "~1.8.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
+      "deprecated": "versions below 1.x are no longer maintained",
+      "license": "GPL-3.0-only",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.2.tgz",
+      "integrity": "sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/connect-known-chains": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.10.3.tgz",
+      "integrity": "sha512-OJEZO1Pagtb6bNE3wCikc2wrmvEU5x7GxFFLqqbz1AJYYxSlrPCGu4N2og5YTExo4IcloNMQYFRkBGue0BKZ4w==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/light-client-extension-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "rxjs": "^7.8.1"
+      },
+      "peerDependencies": {
+        "smoldot": "2.x"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.51.0.tgz",
+      "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nock/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scale-ts": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
+      "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/smoldot": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/services/seed-backend/package-lock.json
+++ b/services/seed-backend/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@polkadot/api": "^16.4.1",
-        "@polkadot/keyring": "^13.5.1",
-        "@polkadot/util": "^13.5.1",
-        "@polkadot/util-crypto": "^13.5.1",
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -616,50 +616,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/api-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@polkadot/api-base": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
@@ -671,50 +627,6 @@
         "@polkadot/util": "^14.0.3",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api-base/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api-base/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api-base/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
@@ -741,93 +653,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/api-derive/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@polkadot/keyring": {
+    "node_modules/@polkadot/keyring": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
       "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
@@ -845,110 +671,6 @@
         "@polkadot/util-crypto": "14.0.3"
       }
     },
-    "node_modules/@polkadot/api/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.5.9.tgz",
-      "integrity": "sha512-bMCpHDN7U8ytxawjBZ89/he5s3AmEZuOdkM/ABcorh/flXNPfyghjFK27Gy4OKoFxX52yJ2sTHR4NxM87GuFXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "13.5.9",
-        "@polkadot/util-crypto": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.9",
-        "@polkadot/util-crypto": "13.5.9"
-      }
-    },
     "node_modules/@polkadot/networks": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
@@ -957,50 +679,6 @@
       "dependencies": {
         "@polkadot/util": "14.0.3",
         "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/networks/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/networks/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/networks/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1023,50 +701,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@polkadot/rpc-core": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
@@ -1079,50 +713,6 @@
         "@polkadot/util": "^14.0.3",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/rpc-core/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
@@ -1152,110 +742,6 @@
       },
       "optionalDependencies": {
         "@substrate/connect": "0.8.11"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@polkadot/types": {
@@ -1292,50 +778,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@polkadot/types-codec": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
@@ -1350,50 +792,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@polkadot/types-create": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
@@ -1403,50 +801,6 @@
         "@polkadot/types-codec": "16.5.6",
         "@polkadot/util": "^14.0.3",
         "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-create/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-create/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
@@ -1469,50 +823,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/types-known/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-known/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-known/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@polkadot/types-support": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
@@ -1526,7 +836,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/types-support/node_modules/@polkadot/util": {
+    "node_modules/@polkadot/util": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
       "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
@@ -1544,69 +854,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/types-support/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types-support/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/util-crypto": {
+    "node_modules/@polkadot/util-crypto": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
       "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
@@ -1629,155 +877,6 @@
       },
       "peerDependencies": {
         "@polkadot/util": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
-      "integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "13.5.9",
-        "@polkadot/x-global": "13.5.9",
-        "@polkadot/x-textdecoder": "13.5.9",
-        "@polkadot/x-textencoder": "13.5.9",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.5.9.tgz",
-      "integrity": "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "13.5.9",
-        "@polkadot/util": "13.5.9",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "13.5.9",
-        "@polkadot/x-randomvalues": "13.5.9",
-        "@scure/base": "^1.1.7",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.9"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/networks": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.9.tgz",
-      "integrity": "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "13.5.9",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
-      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
-      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
-      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util/node_modules/@polkadot/x-global": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
-      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -1924,53 +1023,29 @@
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.9.tgz",
-      "integrity": "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.5.9",
+        "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.5.9",
+        "@polkadot/util": "14.0.3",
         "@polkadot/wasm-util": "*"
       }
     },
-    "node_modules/@polkadot/x-randomvalues/node_modules/@polkadot/x-global": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
-      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.9.tgz",
-      "integrity": "sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
-      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1978,24 +1053,12 @@
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.9.tgz",
-      "integrity": "sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
-      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {

--- a/services/seed-backend/package.json
+++ b/services/seed-backend/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "migrate": "node lib/migrate.js",
     "start": "node lib/main.js",
     "dev": "tsx watch src/main.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
@@ -16,9 +17,9 @@
   },
   "dependencies": {
     "@polkadot/api": "^16.4.1",
-    "@polkadot/keyring": "^13.5.1",
-    "@polkadot/util": "^13.5.1",
-    "@polkadot/util-crypto": "^13.5.1",
+    "@polkadot/keyring": "^14.0.3",
+    "@polkadot/util": "^14.0.3",
+    "@polkadot/util-crypto": "^14.0.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",

--- a/services/seed-backend/package.json
+++ b/services/seed-backend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@vara-agent-network/seed-backend",
+  "version": "0.1.0",
+  "description": "Server-managed VARA seed allocation backend for Vara Agent Network hackathon apps",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node lib/main.js",
+    "dev": "tsx watch src/main.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@polkadot/api": "^16.4.1",
+    "@polkadot/keyring": "^13.5.1",
+    "@polkadot/util": "^13.5.1",
+    "@polkadot/util-crypto": "^13.5.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "pg": "^8.13.1"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.13.1",
+    "@types/pg": "^8.11.11",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/services/seed-backend/package.json
+++ b/services/seed-backend/package.json
@@ -11,7 +11,8 @@
     "build": "tsc -p tsconfig.json",
     "start": "node lib/main.js",
     "dev": "tsx watch src/main.ts",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@polkadot/api": "^16.4.1",

--- a/services/seed-backend/src/address.test.ts
+++ b/services/seed-backend/src/address.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeAddress } from "./address.js";
+
+test("normalizeAddress accepts codec-like objects with toString", () => {
+  const codecLike = {
+    toString() {
+      return "0xABCDEF";
+    },
+  };
+
+  assert.equal(normalizeAddress(codecLike), "0xabcdef");
+});
+
+test("normalizeAddress still rejects plain objects without a useful string value", () => {
+  assert.equal(normalizeAddress({}), null);
+});

--- a/services/seed-backend/src/address.ts
+++ b/services/seed-backend/src/address.ts
@@ -2,12 +2,13 @@ import { u8aToHex } from "@polkadot/util";
 import { decodeAddress } from "@polkadot/util-crypto";
 
 export function normalizeAddress(input: unknown): string | null {
-  if (typeof input !== "string") return null;
-  if (input.startsWith("0x")) return input.toLowerCase();
+  const value = stringifyAddressLike(input);
+  if (!value) return null;
+  if (value.startsWith("0x")) return value.toLowerCase();
   try {
-    return u8aToHex(decodeAddress(input)).toLowerCase();
+    return u8aToHex(decodeAddress(value)).toLowerCase();
   } catch {
-    return input.toLowerCase();
+    return value.toLowerCase();
   }
 }
 
@@ -29,4 +30,13 @@ export function toBigIntString(value: unknown): string {
     if (typeof maybe.toString === "function") return maybe.toString().replaceAll(",", "");
   }
   return "0";
+}
+
+function stringifyAddressLike(input: unknown): string | null {
+  if (typeof input === "string") return input;
+  if (input && typeof input === "object") {
+    const asString = String(input);
+    if (asString && asString !== "[object Object]") return asString;
+  }
+  return null;
 }

--- a/services/seed-backend/src/address.ts
+++ b/services/seed-backend/src/address.ts
@@ -1,0 +1,32 @@
+import { u8aToHex } from "@polkadot/util";
+import { decodeAddress } from "@polkadot/util-crypto";
+
+export function normalizeAddress(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  if (input.startsWith("0x")) return input.toLowerCase();
+  try {
+    return u8aToHex(decodeAddress(input)).toLowerCase();
+  } catch {
+    return input.toLowerCase();
+  }
+}
+
+export function requireAddress(input: unknown, name: string): string {
+  const value = normalizeAddress(input);
+  if (!value || !value.startsWith("0x")) {
+    throw new Error(`${name} is not a valid SS58 or hex address`);
+  }
+  return value;
+}
+
+export function toBigIntString(value: unknown): string {
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number") return Math.trunc(value).toString();
+  if (typeof value === "string") return value.replaceAll(",", "");
+  if (value && typeof value === "object") {
+    const maybe = value as { toBigInt?: () => bigint; toString?: () => string };
+    if (typeof maybe.toBigInt === "function") return maybe.toBigInt().toString();
+    if (typeof maybe.toString === "function") return maybe.toString().replaceAll(",", "");
+  }
+  return "0";
+}

--- a/services/seed-backend/src/chain.ts
+++ b/services/seed-backend/src/chain.ts
@@ -1,0 +1,195 @@
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import { Keyring } from "@polkadot/keyring";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import { config } from "./config.js";
+import { normalizeAddress, requireAddress, toBigIntString } from "./address.js";
+import { log } from "./logger.js";
+
+type Api = ApiPromise;
+
+export interface SpendEvent {
+  id: string;
+  wallet: string;
+  recipient: string;
+  amountRaw: bigint;
+  kind: "balances_transfer" | "gear_value";
+  substrateBlockNumber: number;
+  substrateBlockTs: Date;
+  extrinsicIdx: number | null;
+  eventIdx: number | null;
+}
+
+export class ChainClient {
+  private api: Api | null = null;
+  private account: ReturnType<Keyring["addFromUri"]> | null = null;
+
+  async connect(): Promise<Api> {
+    if (this.api) return this.api;
+    await cryptoWaitReady();
+    const provider = new WsProvider(config.varaRpcUrl);
+    this.api = await ApiPromise.create({ provider });
+
+    const keyring = new Keyring({ type: "sr25519" });
+    this.account = keyring.addFromUri(config.seedAccount);
+    const chain = (await this.api.rpc.system.chain()).toString();
+    log.info("seed backend connected to chain", {
+      chain,
+      endpoint: config.varaRpcUrl,
+      seedAddress: this.account.address,
+    });
+    return this.api;
+  }
+
+  async finalizedHeight(): Promise<number> {
+    const api = await this.connect();
+    const hash = await api.rpc.chain.getFinalizedHead();
+    const header = await api.rpc.chain.getHeader(hash);
+    return header.number.toNumber();
+  }
+
+  async balanceOf(address: string): Promise<bigint> {
+    const api = await this.connect();
+    const normalized = requireAddress(address, "address");
+    const account = await api.query.system.account(normalized);
+    return BigInt((account as unknown as { data: { free: { toString(): string } } }).data.free.toString());
+  }
+
+  async transfer(to: string, amountRaw: bigint): Promise<string> {
+    const api = await this.connect();
+    if (!this.account) throw new Error("seed account is not initialized");
+    const recipient = requireAddress(to, "recipient");
+
+    const balances = api.tx.balances as unknown as {
+      transferKeepAlive?: (dest: string, value: bigint) => SubmittableExtrinsic<"promise">;
+      transferAllowDeath?: (dest: string, value: bigint) => SubmittableExtrinsic<"promise">;
+      transfer?: (dest: string, value: bigint) => SubmittableExtrinsic<"promise">;
+    };
+
+    const tx =
+      balances.transferKeepAlive?.(recipient, amountRaw) ??
+      balances.transferAllowDeath?.(recipient, amountRaw) ??
+      balances.transfer?.(recipient, amountRaw);
+
+    if (!tx) throw new Error("balances transfer call is not available in this runtime");
+
+    return new Promise<string>((resolve, reject) => {
+      let unsub: (() => void) | undefined;
+      const timeout = setTimeout(() => {
+        unsub?.();
+        reject(new Error("transfer timed out before finalization"));
+      }, 120_000);
+
+      tx.signAndSend(this.account!, (result) => {
+        if (result.dispatchError) {
+          clearTimeout(timeout);
+          unsub?.();
+          reject(new Error(result.dispatchError.toString()));
+          return;
+        }
+        if (result.status.isFinalized || result.status.isInBlock) {
+          clearTimeout(timeout);
+          unsub?.();
+          resolve(result.txHash.toHex());
+        }
+      })
+        .then((u) => {
+          unsub = u;
+        })
+        .catch((err) => {
+          clearTimeout(timeout);
+          reject(err);
+        });
+    });
+  }
+
+  async readSpendEvents(blockNumber: number, fundedWallets: Set<string>): Promise<SpendEvent[]> {
+    if (fundedWallets.size === 0) return [];
+    const api = await this.connect();
+    const blockHash = await api.rpc.chain.getBlockHash(blockNumber);
+    const apiAt = await api.at(blockHash);
+    const [eventsRaw, block, timestampRaw] = await Promise.all([
+      apiAt.query.system.events(),
+      api.rpc.chain.getBlock(blockHash),
+      apiAt.query.timestamp.now(),
+    ]);
+
+    const timestamp = new Date(Number((timestampRaw as unknown as { toBigInt(): bigint }).toBigInt()));
+    const events: SpendEvent[] = [];
+    const extrinsics = block.block.extrinsics;
+    const records = eventsRaw as unknown as Array<{
+      phase: { isApplyExtrinsic?: boolean; asApplyExtrinsic?: { toNumber(): number } };
+      event: {
+        section: string;
+        method: string;
+        data: unknown[];
+      };
+    }>;
+
+    records.forEach((record, eventIdx) => {
+      if (record.event.section !== "balances" || record.event.method !== "Transfer") return;
+      const data = record.event.data;
+      const from = normalizeAddress(data[0]);
+      const to = normalizeAddress(data[1]);
+      const amountRaw = BigInt(toBigIntString(data[2]));
+      if (!from || !to || amountRaw <= 0n || !fundedWallets.has(from)) return;
+      const extrinsicIdx = record.phase.isApplyExtrinsic ? record.phase.asApplyExtrinsic?.toNumber() ?? null : null;
+      events.push({
+        id: `balances:${blockNumber}:${eventIdx}`,
+        wallet: from,
+        recipient: to,
+        amountRaw,
+        kind: "balances_transfer",
+        substrateBlockNumber: blockNumber,
+        substrateBlockTs: timestamp,
+        extrinsicIdx,
+        eventIdx,
+      });
+    });
+
+    extrinsics.forEach((extrinsic, extrinsicIdx) => {
+      if (!extrinsic.isSigned) return;
+      const signer = normalizeAddress(extrinsic.signer.toString());
+      if (!signer || !fundedWallets.has(signer)) return;
+      const method = extrinsic.method;
+      if (method.section !== "gear") return;
+      const methodName = method.method.toLowerCase();
+      if (!methodName.includes("send")) return;
+
+      const args = method.args;
+      const metaArgs = method.meta.args;
+      const argByName = new Map<string, unknown>();
+      metaArgs.forEach((argMeta, idx) => {
+        argByName.set(argMeta.name.toString().toLowerCase(), args[idx]);
+      });
+
+      const destinationRaw =
+        argByName.get("destination") ??
+        argByName.get("dest") ??
+        argByName.get("program_id") ??
+        args[0];
+      const valueRaw =
+        argByName.get("value") ??
+        argByName.get("amount") ??
+        args[3];
+
+      const recipient = normalizeAddress(String(destinationRaw));
+      const amountRaw = BigInt(toBigIntString(valueRaw));
+      if (!recipient || amountRaw <= 0n) return;
+
+      events.push({
+        id: `gear-value:${blockNumber}:${extrinsicIdx}`,
+        wallet: signer,
+        recipient,
+        amountRaw,
+        kind: "gear_value",
+        substrateBlockNumber: blockNumber,
+        substrateBlockTs: timestamp,
+        extrinsicIdx,
+        eventIdx: null,
+      });
+    });
+
+    return events;
+  }
+}

--- a/services/seed-backend/src/chain.ts
+++ b/services/seed-backend/src/chain.ts
@@ -87,7 +87,7 @@ export class ChainClient {
           reject(new Error(result.dispatchError.toString()));
           return;
         }
-        if (result.status.isFinalized || result.status.isInBlock) {
+        if (result.status.isFinalized) {
           clearTimeout(timeout);
           unsub?.();
           resolve(result.txHash.toHex());
@@ -129,8 +129,8 @@ export class ChainClient {
     records.forEach((record, eventIdx) => {
       if (record.event.section !== "balances" || record.event.method !== "Transfer") return;
       const data = record.event.data;
-      const from = normalizeAddress(data[0]);
-      const to = normalizeAddress(data[1]);
+      const from = normalizeAddress(String(data[0]));
+      const to = normalizeAddress(String(data[1]));
       const amountRaw = BigInt(toBigIntString(data[2]));
       if (!from || !to || amountRaw <= 0n || !fundedWallets.has(from)) return;
       const extrinsicIdx = record.phase.isApplyExtrinsic ? record.phase.asApplyExtrinsic?.toNumber() ?? null : null;

--- a/services/seed-backend/src/chain.ts
+++ b/services/seed-backend/src/chain.ts
@@ -8,12 +8,15 @@ import { log } from "./logger.js";
 
 type Api = ApiPromise;
 
+const GEAR_BANK_ADDRESS = "0x6d6f646c70792f6762616e6b0000000000000000000000000000000000000000";
+
 export interface SpendEvent {
   id: string;
   wallet: string;
   recipient: string;
   amountRaw: bigint;
-  kind: "balances_transfer" | "gear_value";
+  kind: "balances_transfer" | "gear_value" | "tainted_program_value";
+  sourceProgram?: string;
   substrateBlockNumber: number;
   substrateBlockTs: Date;
   extrinsicIdx: number | null;
@@ -103,8 +106,12 @@ export class ChainClient {
     });
   }
 
-  async readSpendEvents(blockNumber: number, fundedWallets: Set<string>): Promise<SpendEvent[]> {
-    if (fundedWallets.size === 0) return [];
+  async readSpendEvents(
+    blockNumber: number,
+    fundedWallets: Set<string>,
+    taintedPrograms: Set<string> = new Set(),
+  ): Promise<SpendEvent[]> {
+    if (fundedWallets.size === 0 && taintedPrograms.size === 0) return [];
     const api = await this.connect();
     const blockHash = await api.rpc.chain.getBlockHash(blockNumber);
     const apiAt = await api.at(blockHash);
@@ -127,11 +134,35 @@ export class ChainClient {
     }>;
 
     records.forEach((record, eventIdx) => {
+      if (record.event.section === "gear" && record.event.method.toLowerCase() === "usermessagesent") {
+        const message = codecObject(record.event.data[0]);
+        const source = normalizeAddress(String(messageField(message, "source") ?? ""));
+        const destination = normalizeAddress(String(messageField(message, "destination") ?? ""));
+        const valueRaw = messageField(message, "value");
+        const amountRaw = valueRaw === undefined ? 0n : BigInt(toBigIntString(valueRaw));
+        if (!source || !destination || amountRaw <= 0n || !taintedPrograms.has(source)) return;
+        const extrinsicIdx = record.phase.isApplyExtrinsic ? record.phase.asApplyExtrinsic?.toNumber() ?? null : null;
+        events.push({
+          id: `tainted-program-value:${blockNumber}:${eventIdx}`,
+          wallet: source,
+          recipient: destination,
+          amountRaw,
+          kind: "tainted_program_value",
+          sourceProgram: source,
+          substrateBlockNumber: blockNumber,
+          substrateBlockTs: timestamp,
+          extrinsicIdx,
+          eventIdx,
+        });
+        return;
+      }
+
       if (record.event.section !== "balances" || record.event.method !== "Transfer") return;
       const data = record.event.data;
       const from = normalizeAddress(String(data[0]));
       const to = normalizeAddress(String(data[1]));
       const amountRaw = BigInt(toBigIntString(data[2]));
+      if (to === GEAR_BANK_ADDRESS) return;
       if (!from || !to || amountRaw <= 0n || !fundedWallets.has(from)) return;
       const extrinsicIdx = record.phase.isApplyExtrinsic ? record.phase.asApplyExtrinsic?.toNumber() ?? null : null;
       events.push({
@@ -192,4 +223,28 @@ export class ChainClient {
 
     return events;
   }
+}
+
+function codecObject(input: unknown): Record<string, unknown> {
+  if (input && typeof input === "object") {
+    const maybeJson = input as { toJSON?: () => unknown };
+    if (typeof maybeJson.toJSON === "function") {
+      const json = maybeJson.toJSON();
+      if (json && typeof json === "object") return json as Record<string, unknown>;
+    }
+    return input as Record<string, unknown>;
+  }
+  return {};
+}
+
+function messageField(message: Record<string, unknown>, field: string): unknown {
+  const direct = message[field];
+  if (direct !== undefined) return direct;
+
+  const nested = message.message;
+  if (nested && typeof nested === "object") {
+    return (nested as Record<string, unknown>)[field];
+  }
+
+  return undefined;
 }

--- a/services/seed-backend/src/config.ts
+++ b/services/seed-backend/src/config.ts
@@ -27,13 +27,6 @@ function monitorStartBlock(): number | "latest" {
   return value;
 }
 
-function statuses(): string[] {
-  return (process.env.ELIGIBLE_STATUSES ?? "Submitted,Live,Finalist,Winner")
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
 export const config = {
   port: intEnv("PORT", "3002", 1),
   corsOrigin: process.env.API_CORS_ORIGIN ?? "",
@@ -41,7 +34,6 @@ export const config = {
   databaseUrl: required("DATABASE_URL"),
   varaRpcUrl: required("VARA_RPC_URL"),
   seedAccount: required("SEED_ACCOUNT"),
-  eligibleStatuses: statuses(),
   varaDecimals: intEnv("VARA_DECIMALS", "12", 0),
   initialTargetVara: intEnv("INITIAL_TARGET_VARA", "10", 1),
   refillTargetVara: intEnv("REFILL_TARGET_VARA", "10", 1),

--- a/services/seed-backend/src/config.ts
+++ b/services/seed-backend/src/config.ts
@@ -1,0 +1,50 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is not set`);
+  return value;
+}
+
+function intEnv(name: string, fallback: string, min = 0): number {
+  const raw = process.env[name] ?? fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < min) {
+    throw new Error(`${name} must be an integer >= ${min} (got "${raw}")`);
+  }
+  return value;
+}
+
+function statuses(): string[] {
+  return (process.env.ELIGIBLE_STATUSES ?? "Submitted,Live,Finalist,Winner")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export const config = {
+  port: intEnv("PORT", "3002", 1),
+  corsOrigin: process.env.API_CORS_ORIGIN ?? "",
+  apiKey: process.env.SEED_API_KEY ?? "",
+  databaseUrl: required("DATABASE_URL"),
+  varaRpcUrl: required("VARA_RPC_URL"),
+  seedAccount: required("SEED_ACCOUNT"),
+  eligibleStatuses: statuses(),
+  varaDecimals: intEnv("VARA_DECIMALS", "12", 0),
+  initialTargetVara: intEnv("INITIAL_TARGET_VARA", "10", 1),
+  refillTargetVara: intEnv("REFILL_TARGET_VARA", "10", 1),
+  maxDailyRefillVara: intEnv("MAX_DAILY_REFILL_VARA", "100", 1),
+  minRefillIntervalSec: intEnv("MIN_REFILL_INTERVAL_SEC", "3600", 1),
+  suspiciousPauseThresholdVara: intEnv("SUSPICIOUS_PAUSE_THRESHOLD_VARA", "5", 1),
+  blacklistThreshold: intEnv("BLACKLIST_THRESHOLD", "3", 1),
+  monitorStartBlock: intEnv("MONITOR_START_BLOCK", "0", 0),
+  monitorPollIntervalMs: intEnv("MONITOR_POLL_INTERVAL_MS", "6000", 1000),
+  githubToken: process.env.GITHUB_TOKEN ?? "",
+  recentCommitDays: intEnv("RECENT_COMMIT_DAYS", "45", 1),
+};
+
+export function varaToPlanck(vara: number): bigint {
+  return BigInt(vara) * 10n ** BigInt(config.varaDecimals);
+}

--- a/services/seed-backend/src/config.ts
+++ b/services/seed-backend/src/config.ts
@@ -17,6 +17,16 @@ function intEnv(name: string, fallback: string, min = 0): number {
   return value;
 }
 
+function monitorStartBlock(): number | "latest" {
+  const raw = process.env.MONITOR_START_BLOCK ?? "latest";
+  if (raw.toLowerCase() === "latest") return "latest";
+  const value = Number(raw);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(`MONITOR_START_BLOCK must be "latest" or an integer >= 0 (got "${raw}")`);
+  }
+  return value;
+}
+
 function statuses(): string[] {
   return (process.env.ELIGIBLE_STATUSES ?? "Submitted,Live,Finalist,Winner")
     .split(",")
@@ -36,14 +46,25 @@ export const config = {
   initialTargetVara: intEnv("INITIAL_TARGET_VARA", "10", 1),
   refillTargetVara: intEnv("REFILL_TARGET_VARA", "10", 1),
   maxDailyRefillVara: intEnv("MAX_DAILY_REFILL_VARA", "100", 1),
-  minRefillIntervalSec: intEnv("MIN_REFILL_INTERVAL_SEC", "3600", 1),
+  globalDailyPayoutLimitVara: intEnv("GLOBAL_DAILY_PAYOUT_LIMIT_VARA", "1000", 1),
+  lifetimeCapAppVara: intEnv("LIFETIME_CAP_APP_VARA", "100", 1),
+  lifetimeCapWalletVara: intEnv("LIFETIME_CAP_WALLET_VARA", "300", 1),
+  lifetimeCapGithubVara: intEnv("LIFETIME_CAP_GITHUB_VARA", "300", 1),
+  lifetimeCapRepoVara: intEnv("LIFETIME_CAP_REPO_VARA", "100", 1),
+  minRefillIntervalSec: intEnv("MIN_REFILL_INTERVAL_SEC", "86400", 1),
   suspiciousPauseThresholdVara: intEnv("SUSPICIOUS_PAUSE_THRESHOLD_VARA", "5", 1),
   blacklistThreshold: intEnv("BLACKLIST_THRESHOLD", "3", 1),
-  monitorStartBlock: intEnv("MONITOR_START_BLOCK", "0", 0),
+  monitorStartBlock: monitorStartBlock(),
   monitorPollIntervalMs: intEnv("MONITOR_POLL_INTERVAL_MS", "6000", 1000),
   githubToken: process.env.GITHUB_TOKEN ?? "",
   recentCommitDays: intEnv("RECENT_COMMIT_DAYS", "45", 1),
+  githubValidationTtlSec: intEnv("GITHUB_VALIDATION_TTL_SEC", "86400", 1),
+  minRefillActivityEvents: intEnv("MIN_REFILL_ACTIVITY_EVENTS", "1", 0),
 };
+
+if (process.env.NODE_ENV === "production" && !config.apiKey) {
+  throw new Error("SEED_API_KEY is required when NODE_ENV=production");
+}
 
 export function varaToPlanck(vara: number): bigint {
   return BigInt(vara) * 10n ** BigInt(config.varaDecimals);

--- a/services/seed-backend/src/config.ts
+++ b/services/seed-backend/src/config.ts
@@ -17,6 +17,13 @@ function intEnv(name: string, fallback: string, min = 0): number {
   return value;
 }
 
+function boolEnv(name: string, fallback: string): boolean {
+  const raw = (process.env[name] ?? fallback).toLowerCase();
+  if (["1", "true", "yes", "on"].includes(raw)) return true;
+  if (["0", "false", "no", "off"].includes(raw)) return false;
+  throw new Error(`${name} must be a boolean value (got "${process.env[name]}")`);
+}
+
 function monitorStartBlock(): number | "latest" {
   const raw = process.env.MONITOR_START_BLOCK ?? "latest";
   if (raw.toLowerCase() === "latest") return "latest";
@@ -32,19 +39,21 @@ export const config = {
   corsOrigin: process.env.API_CORS_ORIGIN ?? "",
   apiKey: process.env.SEED_API_KEY ?? "",
   databaseUrl: required("DATABASE_URL"),
-  varaRpcUrl: required("VARA_RPC_URL"),
-  seedAccount: required("SEED_ACCOUNT"),
+  seedAutoMigrate: boolEnv("SEED_AUTO_MIGRATE", "true"),
+  varaRpcUrl: process.env.VARA_RPC_URL ?? "",
+  seedAccount: process.env.SEED_ACCOUNT ?? "",
   varaDecimals: intEnv("VARA_DECIMALS", "12", 0),
-  initialTargetVara: intEnv("INITIAL_TARGET_VARA", "10", 1),
-  refillTargetVara: intEnv("REFILL_TARGET_VARA", "10", 1),
-  maxDailyRefillVara: intEnv("MAX_DAILY_REFILL_VARA", "100", 1),
-  globalDailyPayoutLimitVara: intEnv("GLOBAL_DAILY_PAYOUT_LIMIT_VARA", "1000", 1),
-  lifetimeCapAppVara: intEnv("LIFETIME_CAP_APP_VARA", "100", 1),
-  lifetimeCapWalletVara: intEnv("LIFETIME_CAP_WALLET_VARA", "300", 1),
-  lifetimeCapGithubVara: intEnv("LIFETIME_CAP_GITHUB_VARA", "300", 1),
-  lifetimeCapRepoVara: intEnv("LIFETIME_CAP_REPO_VARA", "100", 1),
+  initialTargetVara: intEnv("INITIAL_TARGET_VARA", "500", 1),
+  refillTargetVara: intEnv("REFILL_TARGET_VARA", "2000", 1),
+  refillTriggerBalanceVara: intEnv("REFILL_TRIGGER_BALANCE_VARA", "0", 0),
+  maxDailyRefillVara: intEnv("MAX_DAILY_REFILL_VARA", "2000", 1),
+  globalDailyPayoutLimitVara: intEnv("GLOBAL_DAILY_PAYOUT_LIMIT_VARA", "40000", 1),
+  lifetimeCapAppVara: intEnv("LIFETIME_CAP_APP_VARA", "2000", 1),
+  lifetimeCapWalletVara: intEnv("LIFETIME_CAP_WALLET_VARA", "10000", 1),
+  lifetimeCapGithubVara: intEnv("LIFETIME_CAP_GITHUB_VARA", "10000", 1),
+  lifetimeCapRepoVara: intEnv("LIFETIME_CAP_REPO_VARA", "2000", 1),
   minRefillIntervalSec: intEnv("MIN_REFILL_INTERVAL_SEC", "86400", 1),
-  suspiciousPauseThresholdVara: intEnv("SUSPICIOUS_PAUSE_THRESHOLD_VARA", "5", 1),
+  suspiciousPauseThresholdVara: intEnv("SUSPICIOUS_PAUSE_THRESHOLD_VARA", "10", 1),
   blacklistThreshold: intEnv("BLACKLIST_THRESHOLD", "3", 1),
   monitorStartBlock: monitorStartBlock(),
   monitorPollIntervalMs: intEnv("MONITOR_POLL_INTERVAL_MS", "6000", 1000),
@@ -52,10 +61,28 @@ export const config = {
   recentCommitDays: intEnv("RECENT_COMMIT_DAYS", "45", 1),
   githubValidationTtlSec: intEnv("GITHUB_VALIDATION_TTL_SEC", "86400", 1),
   minRefillActivityEvents: intEnv("MIN_REFILL_ACTIVITY_EVENTS", "1", 0),
+  indexerGraphqlUrl: process.env.INDEXER_GRAPHQL_URL ?? "",
+  applicationSyncEnabled: boolEnv(
+    "APPLICATION_SYNC_ENABLED",
+    process.env.NODE_ENV === "production" ? "false" : "true",
+  ),
+  applicationSyncIntervalSec: intEnv("APPLICATION_SYNC_INTERVAL_SEC", "300", 0),
+  autoClaimIntervalSec: intEnv("AUTO_CLAIM_INTERVAL_SEC", "0", 0),
+  autoRefillIntervalSec: intEnv("AUTO_REFILL_INTERVAL_SEC", "0", 0),
 };
 
-if (process.env.NODE_ENV === "production" && !config.apiKey) {
-  throw new Error("SEED_API_KEY is required when NODE_ENV=production");
+export function validateRuntimeConfig(): void {
+  if (!config.varaRpcUrl) throw new Error("VARA_RPC_URL is not set");
+  if (!config.seedAccount) throw new Error("SEED_ACCOUNT is not set");
+  if (process.env.NODE_ENV === "production" && !config.apiKey) {
+    throw new Error("SEED_API_KEY is required when NODE_ENV=production");
+  }
+  if (process.env.NODE_ENV === "production" && !config.githubToken) {
+    throw new Error("GITHUB_TOKEN is required when NODE_ENV=production");
+  }
+  if (process.env.NODE_ENV === "production" && config.indexerGraphqlUrl && config.applicationSyncEnabled) {
+    throw new Error("APPLICATION_SYNC_ENABLED must be false in production shared-DB mode");
+  }
 }
 
 export function varaToPlanck(vara: number): bigint {

--- a/services/seed-backend/src/db.ts
+++ b/services/seed-backend/src/db.ts
@@ -1,5 +1,6 @@
 import pg from "pg";
 import { config } from "./config.js";
+import { mostRestrictiveAllocationState, type AllocationState } from "./decision.js";
 
 export const pool = new pg.Pool({
   connectionString: config.databaseUrl,
@@ -13,6 +14,7 @@ export interface ApplicationRow {
   github_url: string;
   status: string;
   season_id: number;
+  registered_at: bigint;
 }
 
 export interface AllocationRow {
@@ -141,6 +143,24 @@ export async function ensureSchema(): Promise<void> {
     CREATE INDEX IF NOT EXISTS seed_spend_events_wallet_idx ON seed_spend_events(wallet);
     CREATE INDEX IF NOT EXISTS seed_spend_events_allowed_idx ON seed_spend_events(allowed);
 
+    CREATE TABLE IF NOT EXISTS seed_taint_targets (
+      id bigserial PRIMARY KEY,
+      source_wallet text NOT NULL,
+      source_application_id text NOT NULL,
+      program_id text NOT NULL,
+      amount_raw numeric(78,0) NOT NULL DEFAULT 0,
+      first_seen_block int NOT NULL,
+      last_seen_block int NOT NULL,
+      last_event_id text NOT NULL,
+      state text NOT NULL DEFAULT 'active',
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (source_wallet, source_application_id, program_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS seed_taint_targets_program_idx ON seed_taint_targets(program_id);
+    CREATE INDEX IF NOT EXISTS seed_taint_targets_source_wallet_idx ON seed_taint_targets(source_wallet);
+
     CREATE TABLE IF NOT EXISTS seed_monitor_cursor (
       id text PRIMARY KEY,
       last_processed_block int NOT NULL,
@@ -159,10 +179,63 @@ export async function ensureSchema(): Promise<void> {
   `);
 }
 
+export async function validateDatabaseSchema(): Promise<void> {
+  await requireColumns("applications", [
+    "id",
+    "handle",
+    "owner",
+    "github_url",
+    "status",
+    "season_id",
+    "registered_at",
+  ]);
+
+  for (const table of [
+    "seed_allocations",
+    "seed_payouts",
+    "seed_funding_events",
+    "seed_spend_events",
+    "seed_taint_targets",
+    "seed_monitor_cursor",
+    "seed_audit_events",
+  ]) {
+    await requireTable(table);
+  }
+}
+
+async function requireTable(tableName: string): Promise<void> {
+  const rows = await pool.query<{ exists: boolean }>(
+    `SELECT to_regclass($1) IS NOT NULL AS exists`,
+    [`public.${tableName}`],
+  );
+  if (!rows.rows[0]?.exists) {
+    throw new Error(`required database table "${tableName}" is missing; run seed-backend migrations first`);
+  }
+}
+
+async function requireColumns(tableName: string, columnNames: string[]): Promise<void> {
+  await requireTable(tableName);
+  const rows = await pool.query<{ column_name: string }>(
+    `
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = $1
+        AND column_name = ANY($2::text[])
+    `,
+    [tableName, columnNames],
+  );
+  const found = new Set(rows.rows.map((row) => row.column_name));
+  const missing = columnNames.filter((columnName) => !found.has(columnName));
+  if (missing.length > 0) {
+    throw new Error(`required database table "${tableName}" is missing columns: ${missing.join(", ")}`);
+  }
+}
+
 export async function getEligibleApplication(applicationId: string): Promise<ApplicationRow | null> {
   const rows = await pool.query<ApplicationRow>(
     `
-      SELECT id, handle, owner, github_url, status, season_id
+      SELECT id, handle, owner, github_url, status, season_id, registered_at
       FROM applications
       WHERE lower(id) = lower($1)
       LIMIT 1
@@ -172,12 +245,71 @@ export async function getEligibleApplication(applicationId: string): Promise<App
   return rows.rows[0] ?? null;
 }
 
+export async function upsertApplicationsFromIndexer(applications: ApplicationRow[]): Promise<number> {
+  if (applications.length === 0) return 0;
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    for (const app of applications) {
+      await client.query(
+        `
+          INSERT INTO applications (id, handle, owner, github_url, status, season_id, registered_at)
+          VALUES (lower($1), $2, lower($3), $4, $5, $6, $7)
+          ON CONFLICT (id) DO UPDATE SET
+            handle = EXCLUDED.handle,
+            owner = EXCLUDED.owner,
+            github_url = EXCLUDED.github_url,
+            status = EXCLUDED.status,
+            season_id = EXCLUDED.season_id,
+            registered_at = EXCLUDED.registered_at
+        `,
+        [
+          app.id,
+          app.handle,
+          app.owner,
+          app.github_url,
+          app.status,
+          app.season_id,
+          app.registered_at,
+        ],
+      );
+    }
+    await client.query("COMMIT");
+    return applications.length;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 export async function listEligibleApplications(limit = 100): Promise<ApplicationRow[]> {
   const rows = await pool.query<ApplicationRow>(
     `
-      SELECT id, handle, owner, github_url, status, season_id
+      SELECT id, handle, owner, github_url, status, season_id, registered_at
       FROM applications
       ORDER BY registered_at ASC
+      LIMIT $1
+    `,
+    [limit],
+  );
+  return rows.rows;
+}
+
+export async function listUnfundedApplications(limit = 100): Promise<ApplicationRow[]> {
+  const rows = await pool.query<ApplicationRow>(
+    `
+      SELECT a.id, a.handle, a.owner, a.github_url, a.status, a.season_id, a.registered_at
+      FROM applications a
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM seed_allocations sa
+        WHERE sa.application_id = lower(a.id)
+          AND sa.wallet = lower(a.owner)
+          AND sa.total_funded_raw > 0
+      )
+      ORDER BY a.registered_at ASC
       LIMIT $1
     `,
     [limit],
@@ -244,6 +376,55 @@ export async function getAllocationForUpdate(
       FOR UPDATE
     `,
     [wallet, applicationId],
+  );
+  return rows.rows[0] ?? null;
+}
+
+export async function inheritWalletBlockForUpdate(
+  client: pg.PoolClient,
+  wallet: string,
+  applicationId: string,
+): Promise<AllocationRow | null> {
+  const inheritedRows = await client.query<{
+    state: AllocationState;
+    suspicious_count: number;
+    risk_score: number;
+    last_reason: string | null;
+  }>(
+    `
+      SELECT state, suspicious_count, risk_score, last_reason
+      FROM seed_allocations
+      WHERE wallet = lower($1)
+      ORDER BY updated_at DESC
+      FOR UPDATE
+    `,
+    [wallet],
+  );
+  if (inheritedRows.rows.length === 0) return null;
+
+  const inheritedState = mostRestrictiveAllocationState(inheritedRows.rows.map((row) => row.state));
+  if (inheritedState === "active") {
+    return getAllocationForUpdate(client, wallet, applicationId);
+  }
+
+  const inheritedSuspiciousCount = Math.max(...inheritedRows.rows.map((row) => row.suspicious_count));
+  const inheritedRiskScore = Math.max(...inheritedRows.rows.map((row) => row.risk_score));
+  const inheritedReason =
+    inheritedRows.rows.find((row) => row.state === inheritedState && row.last_reason)?.last_reason ??
+    `wallet has existing ${inheritedState} seed allocation`;
+
+  const rows = await client.query<AllocationRow>(
+    `
+      UPDATE seed_allocations
+      SET state = $3,
+          suspicious_count = GREATEST(suspicious_count, $4),
+          risk_score = GREATEST(risk_score, $5),
+          last_reason = COALESCE(last_reason, $6),
+          updated_at = now()
+      WHERE wallet = lower($1) AND application_id = lower($2)
+      RETURNING *
+    `,
+    [wallet, applicationId, inheritedState, inheritedSuspiciousCount, inheritedRiskScore, inheritedReason],
   );
   return rows.rows[0] ?? null;
 }

--- a/services/seed-backend/src/db.ts
+++ b/services/seed-backend/src/db.ts
@@ -20,6 +20,8 @@ export interface AllocationRow {
   wallet: string;
   application_id: string;
   github_url: string;
+  github_owner: string | null;
+  github_repo: string | null;
   state: "active" | "paused" | "blacklisted";
   total_funded_raw: string;
   daily_funded_raw: string;
@@ -34,8 +36,26 @@ export interface AllocationRow {
   updated_at: Date;
 }
 
+export type PayoutStatus = "PENDING" | "SENT" | "FAILED" | "CANCELLED";
+
+export interface PayoutRow {
+  idempotency_key: string;
+  status: PayoutStatus;
+  wallet: string;
+  application_id: string;
+  github_owner: string;
+  github_repo: string;
+  amount_raw: string;
+  reason: string;
+  tx_hash: string | null;
+  error: string | null;
+  created_at: Date;
+  updated_at: Date;
+  sent_at: Date | null;
+}
+
 export interface FundingDecision {
-  status: "funded" | "skipped" | "paused" | "blacklisted";
+  status: "funded" | "pending" | "skipped" | "paused" | "blacklisted";
   applicationId: string;
   wallet: string;
   amountRaw: string;
@@ -67,6 +87,8 @@ export async function ensureSchema(): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS seed_allocations_wallet_idx ON seed_allocations(wallet);
     CREATE INDEX IF NOT EXISTS seed_allocations_state_idx ON seed_allocations(state);
+    ALTER TABLE seed_allocations ADD COLUMN IF NOT EXISTS github_owner text;
+    ALTER TABLE seed_allocations ADD COLUMN IF NOT EXISTS github_repo text;
 
     CREATE TABLE IF NOT EXISTS seed_funding_events (
       id bigserial PRIMARY KEY,
@@ -77,6 +99,30 @@ export async function ensureSchema(): Promise<void> {
       reason text NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now()
     );
+
+    CREATE TABLE IF NOT EXISTS seed_payouts (
+      idempotency_key text PRIMARY KEY,
+      status text NOT NULL,
+      wallet text NOT NULL,
+      application_id text NOT NULL,
+      github_owner text NOT NULL,
+      github_repo text NOT NULL,
+      amount_raw numeric(78,0) NOT NULL,
+      reason text NOT NULL,
+      tx_hash text,
+      error text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      sent_at timestamptz
+    );
+
+    ALTER TABLE seed_payouts ADD COLUMN IF NOT EXISTS error text;
+
+    CREATE INDEX IF NOT EXISTS seed_payouts_status_idx ON seed_payouts(status);
+    CREATE INDEX IF NOT EXISTS seed_payouts_wallet_idx ON seed_payouts(wallet);
+    CREATE INDEX IF NOT EXISTS seed_payouts_app_idx ON seed_payouts(application_id);
+    CREATE INDEX IF NOT EXISTS seed_payouts_github_idx ON seed_payouts(github_owner);
+    CREATE INDEX IF NOT EXISTS seed_payouts_repo_idx ON seed_payouts(github_owner, github_repo);
 
     CREATE TABLE IF NOT EXISTS seed_spend_events (
       id text PRIMARY KEY,
@@ -152,21 +198,40 @@ export async function listAllowedRecipients(): Promise<Set<string>> {
 export async function upsertAllocation(
   app: ApplicationRow,
   githubOk: boolean,
+  githubOwner: string | null,
+  githubRepo: string | null,
 ): Promise<AllocationRow> {
   const rows = await pool.query<AllocationRow>(
     `
-      INSERT INTO seed_allocations (wallet, application_id, github_url, github_ok, github_checked_at)
-      VALUES (lower($1), lower($2), $3, $4, now())
+      INSERT INTO seed_allocations (
+        wallet, application_id, github_url, github_ok, github_checked_at, github_owner, github_repo
+      )
+      VALUES (lower($1), lower($2), $3, $4, now(), lower($5), lower($6))
       ON CONFLICT (wallet, application_id) DO UPDATE SET
         github_url = EXCLUDED.github_url,
         github_ok = EXCLUDED.github_ok,
         github_checked_at = EXCLUDED.github_checked_at,
+        github_owner = EXCLUDED.github_owner,
+        github_repo = EXCLUDED.github_repo,
         updated_at = now()
       RETURNING *
     `,
-    [app.owner, app.id, app.github_url, githubOk],
+    [app.owner, app.id, app.github_url, githubOk, githubOwner, githubRepo],
   );
   return rows.rows[0];
+}
+
+export async function findAllocation(wallet: string, applicationId: string): Promise<AllocationRow | null> {
+  const rows = await pool.query<AllocationRow>(
+    `
+      SELECT *
+      FROM seed_allocations
+      WHERE wallet = lower($1) AND application_id = lower($2)
+      LIMIT 1
+    `,
+    [wallet, applicationId],
+  );
+  return rows.rows[0] ?? null;
 }
 
 export async function getAllocationForUpdate(
@@ -198,6 +263,35 @@ export async function listAllocations(wallet?: string): Promise<AllocationRow[]>
     [wallet ?? null],
   );
   return rows.rows;
+}
+
+export async function listPayouts(status?: string): Promise<PayoutRow[]> {
+  const rows = await pool.query<PayoutRow>(
+    `
+      SELECT idempotency_key, status, wallet, application_id, github_owner, github_repo,
+             amount_raw::text, reason, tx_hash, error, created_at, updated_at, sent_at
+      FROM seed_payouts
+      WHERE ($1::text IS NULL OR status = upper($1))
+      ORDER BY updated_at DESC
+      LIMIT 500
+    `,
+    [status ?? null],
+  );
+  return rows.rows;
+}
+
+export async function getPayoutByKey(idempotencyKey: string): Promise<PayoutRow | null> {
+  const rows = await pool.query<PayoutRow>(
+    `
+      SELECT idempotency_key, status, wallet, application_id, github_owner, github_repo,
+             amount_raw::text, reason, tx_hash, error, created_at, updated_at, sent_at
+      FROM seed_payouts
+      WHERE idempotency_key = $1
+      LIMIT 1
+    `,
+    [idempotencyKey],
+  );
+  return rows.rows[0] ?? null;
 }
 
 export async function recordAudit(

--- a/services/seed-backend/src/db.ts
+++ b/services/seed-backend/src/db.ts
@@ -1,0 +1,217 @@
+import pg from "pg";
+import { config } from "./config.js";
+
+export const pool = new pg.Pool({
+  connectionString: config.databaseUrl,
+  max: 10,
+});
+
+export interface ApplicationRow {
+  id: string;
+  handle: string;
+  owner: string;
+  github_url: string;
+  status: string;
+  season_id: number;
+}
+
+export interface AllocationRow {
+  id: number;
+  wallet: string;
+  application_id: string;
+  github_url: string;
+  state: "active" | "paused" | "blacklisted";
+  total_funded_raw: string;
+  daily_funded_raw: string;
+  daily_window: string;
+  last_funded_at: Date | null;
+  suspicious_count: number;
+  risk_score: number;
+  last_reason: string | null;
+  github_checked_at: Date | null;
+  github_ok: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface FundingDecision {
+  status: "funded" | "skipped" | "paused" | "blacklisted";
+  applicationId: string;
+  wallet: string;
+  amountRaw: string;
+  reason: string;
+  txHash?: string;
+}
+
+export async function ensureSchema(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS seed_allocations (
+      id bigserial PRIMARY KEY,
+      wallet text NOT NULL,
+      application_id text NOT NULL,
+      github_url text NOT NULL,
+      state text NOT NULL DEFAULT 'active',
+      total_funded_raw numeric(78,0) NOT NULL DEFAULT 0,
+      daily_funded_raw numeric(78,0) NOT NULL DEFAULT 0,
+      daily_window date NOT NULL DEFAULT CURRENT_DATE,
+      last_funded_at timestamptz,
+      suspicious_count int NOT NULL DEFAULT 0,
+      risk_score int NOT NULL DEFAULT 0,
+      last_reason text,
+      github_checked_at timestamptz,
+      github_ok boolean NOT NULL DEFAULT false,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (wallet, application_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS seed_allocations_wallet_idx ON seed_allocations(wallet);
+    CREATE INDEX IF NOT EXISTS seed_allocations_state_idx ON seed_allocations(state);
+
+    CREATE TABLE IF NOT EXISTS seed_funding_events (
+      id bigserial PRIMARY KEY,
+      wallet text NOT NULL,
+      application_id text NOT NULL,
+      amount_raw numeric(78,0) NOT NULL,
+      tx_hash text,
+      reason text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+
+    CREATE TABLE IF NOT EXISTS seed_spend_events (
+      id text PRIMARY KEY,
+      wallet text NOT NULL,
+      recipient text NOT NULL,
+      amount_raw numeric(78,0) NOT NULL,
+      kind text NOT NULL,
+      allowed boolean NOT NULL,
+      substrate_block_number int NOT NULL,
+      substrate_block_ts timestamptz NOT NULL,
+      extrinsic_idx int,
+      event_idx int,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX IF NOT EXISTS seed_spend_events_wallet_idx ON seed_spend_events(wallet);
+    CREATE INDEX IF NOT EXISTS seed_spend_events_allowed_idx ON seed_spend_events(allowed);
+
+    CREATE TABLE IF NOT EXISTS seed_monitor_cursor (
+      id text PRIMARY KEY,
+      last_processed_block int NOT NULL,
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+
+    CREATE TABLE IF NOT EXISTS seed_audit_events (
+      id bigserial PRIMARY KEY,
+      wallet text,
+      application_id text,
+      level text NOT NULL,
+      message text NOT NULL,
+      metadata jsonb NOT NULL DEFAULT '{}',
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+}
+
+export async function getEligibleApplication(applicationId: string): Promise<ApplicationRow | null> {
+  const rows = await pool.query<ApplicationRow>(
+    `
+      SELECT id, handle, owner, github_url, status, season_id
+      FROM applications
+      WHERE lower(id) = lower($1)
+        AND status = ANY($2::text[])
+      LIMIT 1
+    `,
+    [applicationId, config.eligibleStatuses],
+  );
+  return rows.rows[0] ?? null;
+}
+
+export async function listEligibleApplications(limit = 100): Promise<ApplicationRow[]> {
+  const rows = await pool.query<ApplicationRow>(
+    `
+      SELECT id, handle, owner, github_url, status, season_id
+      FROM applications
+      WHERE status = ANY($1::text[])
+      ORDER BY registered_at ASC
+      LIMIT $2
+    `,
+    [config.eligibleStatuses, limit],
+  );
+  return rows.rows;
+}
+
+export async function listAllowedRecipients(): Promise<Set<string>> {
+  const rows = await pool.query<{ id: string }>(
+    `SELECT lower(id) AS id FROM applications WHERE status = ANY($1::text[])`,
+    [config.eligibleStatuses],
+  );
+  return new Set(rows.rows.map((r) => r.id));
+}
+
+export async function upsertAllocation(
+  app: ApplicationRow,
+  githubOk: boolean,
+): Promise<AllocationRow> {
+  const rows = await pool.query<AllocationRow>(
+    `
+      INSERT INTO seed_allocations (wallet, application_id, github_url, github_ok, github_checked_at)
+      VALUES (lower($1), lower($2), $3, $4, now())
+      ON CONFLICT (wallet, application_id) DO UPDATE SET
+        github_url = EXCLUDED.github_url,
+        github_ok = EXCLUDED.github_ok,
+        github_checked_at = EXCLUDED.github_checked_at,
+        updated_at = now()
+      RETURNING *
+    `,
+    [app.owner, app.id, app.github_url, githubOk],
+  );
+  return rows.rows[0];
+}
+
+export async function getAllocationForUpdate(
+  client: pg.PoolClient,
+  wallet: string,
+  applicationId: string,
+): Promise<AllocationRow | null> {
+  const rows = await client.query<AllocationRow>(
+    `
+      SELECT *
+      FROM seed_allocations
+      WHERE wallet = lower($1) AND application_id = lower($2)
+      FOR UPDATE
+    `,
+    [wallet, applicationId],
+  );
+  return rows.rows[0] ?? null;
+}
+
+export async function listAllocations(wallet?: string): Promise<AllocationRow[]> {
+  const rows = await pool.query<AllocationRow>(
+    `
+      SELECT *
+      FROM seed_allocations
+      WHERE ($1::text IS NULL OR wallet = lower($1))
+      ORDER BY updated_at DESC
+      LIMIT 500
+    `,
+    [wallet ?? null],
+  );
+  return rows.rows;
+}
+
+export async function recordAudit(
+  level: "info" | "warn" | "error",
+  message: string,
+  metadata: Record<string, unknown> = {},
+  wallet?: string,
+  applicationId?: string,
+): Promise<void> {
+  await pool.query(
+    `
+      INSERT INTO seed_audit_events (wallet, application_id, level, message, metadata)
+      VALUES ($1, $2, $3, $4, $5::jsonb)
+    `,
+    [wallet ?? null, applicationId ?? null, level, message, JSON.stringify(metadata)],
+  );
+}

--- a/services/seed-backend/src/db.ts
+++ b/services/seed-backend/src/db.ts
@@ -165,10 +165,9 @@ export async function getEligibleApplication(applicationId: string): Promise<App
       SELECT id, handle, owner, github_url, status, season_id
       FROM applications
       WHERE lower(id) = lower($1)
-        AND status = ANY($2::text[])
       LIMIT 1
     `,
-    [applicationId, config.eligibleStatuses],
+    [applicationId],
   );
   return rows.rows[0] ?? null;
 }
@@ -178,19 +177,17 @@ export async function listEligibleApplications(limit = 100): Promise<Application
     `
       SELECT id, handle, owner, github_url, status, season_id
       FROM applications
-      WHERE status = ANY($1::text[])
       ORDER BY registered_at ASC
-      LIMIT $2
+      LIMIT $1
     `,
-    [config.eligibleStatuses, limit],
+    [limit],
   );
   return rows.rows;
 }
 
 export async function listAllowedRecipients(): Promise<Set<string>> {
   const rows = await pool.query<{ id: string }>(
-    `SELECT lower(id) AS id FROM applications WHERE status = ANY($1::text[])`,
-    [config.eligibleStatuses],
+    `SELECT lower(id) AS id FROM applications`,
   );
   return new Set(rows.rows.map((r) => r.id));
 }

--- a/services/seed-backend/src/decision.test.ts
+++ b/services/seed-backend/src/decision.test.ts
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  applySpendRisk,
+  isAllowedRecipient,
+  planPayout,
+  type PayoutInputs,
+  type PayoutPolicy,
+} from "./decision.js";
+import { parseGithubUrl } from "./github.js";
+
+const VARA = 1_000_000_000_000n;
+
+const policy: PayoutPolicy = {
+  initialTarget: 10n * VARA,
+  refillTarget: 10n * VARA,
+  walletDailyCap: 100n * VARA,
+  globalDailyCap: 1_000n * VARA,
+  lifetimeCapApp: 100n * VARA,
+  lifetimeCapWallet: 300n * VARA,
+  lifetimeCapGithub: 300n * VARA,
+  lifetimeCapRepo: 100n * VARA,
+  minRefillIntervalMs: 86_400_000,
+};
+
+const baseInput: PayoutInputs = {
+  mode: "initial",
+  state: "active",
+  nowMs: Date.parse("2026-05-05T00:00:00.000Z"),
+  currentBalance: 0n,
+  totalFunded: 0n,
+  walletDailyFunded: 0n,
+  globalDailyFunded: 0n,
+  appLifetimeFunded: 0n,
+  walletLifetimeFunded: 0n,
+  githubLifetimeFunded: 0n,
+  repoLifetimeFunded: 0n,
+  lastFundedAtMs: null,
+};
+
+test("initial top-up funds toward the configured initial target", () => {
+  const result = planPayout(baseInput, policy);
+  assert.equal(result.status, "pay");
+  assert.equal(result.amount, 10n * VARA);
+  assert.equal(result.reason, "initial");
+});
+
+test("initial top-up subtracts existing wallet balance", () => {
+  const result = planPayout({ ...baseInput, currentBalance: 3n * VARA }, policy);
+  assert.equal(result.status, "pay");
+  assert.equal(result.amount, 7n * VARA);
+});
+
+test("refill cooldown blocks payout before the interval elapses", () => {
+  const result = planPayout(
+    {
+      ...baseInput,
+      mode: "refill",
+      totalFunded: 10n * VARA,
+      lastFundedAtMs: baseInput.nowMs - 3_600_000,
+    },
+    policy,
+  );
+  assert.equal(result.status, "skip");
+  assert.match(result.reason, /refill interval has not elapsed/);
+});
+
+test("daily wallet cap limits payout amount", () => {
+  const result = planPayout(
+    {
+      ...baseInput,
+      walletDailyFunded: 95n * VARA,
+    },
+    policy,
+  );
+  assert.equal(result.status, "pay");
+  assert.equal(result.amount, 5n * VARA);
+});
+
+test("lifetime app cap blocks payout", () => {
+  const result = planPayout(
+    {
+      ...baseInput,
+      appLifetimeFunded: 100n * VARA,
+    },
+    policy,
+  );
+  assert.equal(result.status, "skip");
+  assert.equal(result.amount, 0n);
+  assert.equal(result.reason, "lifetime app funding cap reached");
+});
+
+test("paused and blacklisted allocations cannot receive payout", () => {
+  const paused = planPayout({ ...baseInput, state: "paused" }, policy);
+  assert.equal(paused.status, "paused");
+  assert.equal(paused.amount, 0n);
+
+  const blacklisted = planPayout({ ...baseInput, state: "blacklisted" }, policy);
+  assert.equal(blacklisted.status, "blacklisted");
+  assert.equal(blacklisted.amount, 0n);
+});
+
+test("GitHub URL validation accepts github.com owner/repo", () => {
+  const result = parseGithubUrl("https://github.com/vara-network/vara-agent");
+  assert.equal(result.ok, true);
+  assert.equal(result.owner, "vara-network");
+  assert.equal(result.repo, "vara-agent");
+  assert.equal(result.normalizedUrl, "https://github.com/vara-network/vara-agent");
+});
+
+test("GitHub URL validation rejects non-github domains", () => {
+  const result = parseGithubUrl("https://example.com/vara-network/vara-agent");
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "github URL must use github.com domain");
+});
+
+test("suspicious outflow over threshold pauses allocation", () => {
+  const result = applySpendRisk(
+    {
+      allowed: false,
+      amountRaw: 5n * VARA,
+      currentState: "active",
+      suspiciousCount: 0,
+    },
+    { suspiciousPauseThreshold: 5n * VARA, blacklistThreshold: 3 },
+  );
+  assert.equal(result.suspicious, true);
+  assert.equal(result.state, "paused");
+  assert.equal(result.suspiciousCount, 1);
+});
+
+test("repeated suspicious outflow blacklists allocation", () => {
+  const result = applySpendRisk(
+    {
+      allowed: false,
+      amountRaw: 1n,
+      currentState: "paused",
+      suspiciousCount: 2,
+    },
+    { suspiciousPauseThreshold: 5n * VARA, blacklistThreshold: 3 },
+  );
+  assert.equal(result.suspicious, true);
+  assert.equal(result.state, "blacklisted");
+  assert.equal(result.suspiciousCount, 3);
+});
+
+test("allowed recipient is not suspicious", () => {
+  const allowedRecipients = new Set(["0xabc"]);
+  assert.equal(isAllowedRecipient("0xABC", allowedRecipients), true);
+
+  const result = applySpendRisk(
+    {
+      allowed: true,
+      amountRaw: 100n * VARA,
+      currentState: "active",
+      suspiciousCount: 0,
+    },
+    { suspiciousPauseThreshold: 5n * VARA, blacklistThreshold: 3 },
+  );
+  assert.equal(result.suspicious, false);
+  assert.equal(result.state, "active");
+  assert.equal(result.suspiciousCount, 0);
+});

--- a/services/seed-backend/src/decision.test.ts
+++ b/services/seed-backend/src/decision.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   applySpendRisk,
   isAllowedRecipient,
+  mostRestrictiveAllocationState,
   planPayout,
   type PayoutInputs,
   type PayoutPolicy,
@@ -14,6 +15,7 @@ const VARA = 1_000_000_000_000n;
 const policy: PayoutPolicy = {
   initialTarget: 10n * VARA,
   refillTarget: 10n * VARA,
+  refillTriggerBalance: 0n,
   walletDailyCap: 100n * VARA,
   globalDailyCap: 1_000n * VARA,
   lifetimeCapApp: 100n * VARA,
@@ -65,6 +67,42 @@ test("refill cooldown blocks payout before the interval elapses", () => {
   assert.match(result.reason, /refill interval has not elapsed/);
 });
 
+test("refill trigger skips payout until wallet balance drops below threshold", () => {
+  const result = planPayout(
+    {
+      ...baseInput,
+      mode: "refill",
+      currentBalance: 2n * VARA,
+      totalFunded: 10n * VARA,
+      lastFundedAtMs: baseInput.nowMs - 90_000_000,
+    },
+    {
+      ...policy,
+      refillTriggerBalance: 2n * VARA,
+    },
+  );
+  assert.equal(result.status, "skip");
+  assert.equal(result.reason, "wallet balance is above refill trigger");
+});
+
+test("refill trigger allows top-up to refill target when below threshold", () => {
+  const result = planPayout(
+    {
+      ...baseInput,
+      mode: "refill",
+      currentBalance: 1n * VARA,
+      totalFunded: 10n * VARA,
+      lastFundedAtMs: baseInput.nowMs - 90_000_000,
+    },
+    {
+      ...policy,
+      refillTriggerBalance: 2n * VARA,
+    },
+  );
+  assert.equal(result.status, "pay");
+  assert.equal(result.amount, 9n * VARA);
+});
+
 test("daily wallet cap limits payout amount", () => {
   const result = planPayout(
     {
@@ -98,6 +136,12 @@ test("paused and blacklisted allocations cannot receive payout", () => {
   const blacklisted = planPayout({ ...baseInput, state: "blacklisted" }, policy);
   assert.equal(blacklisted.status, "blacklisted");
   assert.equal(blacklisted.amount, 0n);
+});
+
+test("wallet block inheritance keeps the most restrictive allocation state", () => {
+  assert.equal(mostRestrictiveAllocationState(["active", "paused"]), "paused");
+  assert.equal(mostRestrictiveAllocationState(["active", "paused", "blacklisted"]), "blacklisted");
+  assert.equal(mostRestrictiveAllocationState(["active", "active"]), "active");
 });
 
 test("GitHub URL validation accepts github.com owner/repo", () => {

--- a/services/seed-backend/src/decision.ts
+++ b/services/seed-backend/src/decision.ts
@@ -1,0 +1,144 @@
+export type AllocationState = "active" | "paused" | "blacklisted";
+export type FundingMode = "initial" | "refill";
+
+export interface PayoutPolicy {
+  initialTarget: bigint;
+  refillTarget: bigint;
+  walletDailyCap: bigint;
+  globalDailyCap: bigint;
+  lifetimeCapApp: bigint;
+  lifetimeCapWallet: bigint;
+  lifetimeCapGithub: bigint;
+  lifetimeCapRepo: bigint;
+  minRefillIntervalMs: number;
+}
+
+export interface PayoutInputs {
+  mode: FundingMode;
+  state: AllocationState;
+  nowMs: number;
+  currentBalance: bigint;
+  totalFunded: bigint;
+  walletDailyFunded: bigint;
+  globalDailyFunded: bigint;
+  appLifetimeFunded: bigint;
+  walletLifetimeFunded: bigint;
+  githubLifetimeFunded: bigint;
+  repoLifetimeFunded: bigint;
+  lastFundedAtMs: number | null;
+}
+
+export interface PayoutPlan {
+  status: "pay" | "skip" | "paused" | "blacklisted";
+  amount: bigint;
+  reason: string;
+}
+
+export function planPayout(input: PayoutInputs, policy: PayoutPolicy): PayoutPlan {
+  if (input.state === "paused") return { status: "paused", amount: 0n, reason: "allocation is paused" };
+  if (input.state === "blacklisted") {
+    return { status: "blacklisted", amount: 0n, reason: "allocation is blacklisted" };
+  }
+
+  if (input.mode === "refill" && input.lastFundedAtMs !== null) {
+    const nextEligible = input.lastFundedAtMs + policy.minRefillIntervalMs;
+    if (input.nowMs < nextEligible) {
+      return {
+        status: "skip",
+        amount: 0n,
+        reason: `refill interval has not elapsed; next eligible at ${new Date(nextEligible).toISOString()}`,
+      };
+    }
+  }
+
+  const target = input.totalFunded === 0n || input.mode === "initial"
+    ? policy.initialTarget
+    : policy.refillTarget;
+  const needed = target > input.currentBalance ? target - input.currentBalance : 0n;
+  const walletDailyLeft = left(policy.walletDailyCap, input.walletDailyFunded);
+  const globalDailyLeft = left(policy.globalDailyCap, input.globalDailyFunded);
+  const appLeft = left(policy.lifetimeCapApp, input.appLifetimeFunded);
+  const walletLeft = left(policy.lifetimeCapWallet, input.walletLifetimeFunded);
+  const githubLeft = left(policy.lifetimeCapGithub, input.githubLifetimeFunded);
+  const repoLeft = left(policy.lifetimeCapRepo, input.repoLifetimeFunded);
+  const amount = minBigInt(
+    needed,
+    walletDailyLeft,
+    globalDailyLeft,
+    appLeft,
+    walletLeft,
+    githubLeft,
+    repoLeft,
+  );
+
+  if (amount <= 0n) {
+    return {
+      status: "skip",
+      amount: 0n,
+      reason: firstCapReason([
+        [needed, "wallet balance is already at target"],
+        [walletDailyLeft, "daily wallet funding cap reached"],
+        [globalDailyLeft, "global daily payout limit reached"],
+        [appLeft, "lifetime app funding cap reached"],
+        [walletLeft, "lifetime wallet funding cap reached"],
+        [githubLeft, "lifetime github funding cap reached"],
+        [repoLeft, "lifetime repo funding cap reached"],
+      ]),
+    };
+  }
+
+  return { status: "pay", amount, reason: input.mode };
+}
+
+export interface RiskPolicy {
+  suspiciousPauseThreshold: bigint;
+  blacklistThreshold: number;
+}
+
+export interface SpendRiskInput {
+  allowed: boolean;
+  amountRaw: bigint;
+  currentState: AllocationState;
+  suspiciousCount: number;
+}
+
+export interface SpendRiskDecision {
+  suspicious: boolean;
+  state: AllocationState;
+  suspiciousCount: number;
+}
+
+export function applySpendRisk(input: SpendRiskInput, policy: RiskPolicy): SpendRiskDecision {
+  if (input.allowed || input.currentState === "blacklisted") {
+    return {
+      suspicious: false,
+      state: input.currentState,
+      suspiciousCount: input.suspiciousCount,
+    };
+  }
+
+  const nextCount = input.suspiciousCount + 1;
+  if (nextCount >= policy.blacklistThreshold) {
+    return { suspicious: true, state: "blacklisted", suspiciousCount: nextCount };
+  }
+  if (input.amountRaw >= policy.suspiciousPauseThreshold) {
+    return { suspicious: true, state: "paused", suspiciousCount: nextCount };
+  }
+  return { suspicious: true, state: input.currentState, suspiciousCount: nextCount };
+}
+
+export function isAllowedRecipient(recipient: string, allowedRecipients: Set<string>): boolean {
+  return allowedRecipients.has(recipient.toLowerCase());
+}
+
+function left(cap: bigint, used: bigint): bigint {
+  return cap > used ? cap - used : 0n;
+}
+
+function firstCapReason(entries: Array<[bigint, string]>): string {
+  return entries.find(([amount]) => amount <= 0n)?.[1] ?? "funding cap reached";
+}
+
+function minBigInt(...values: bigint[]): bigint {
+  return values.reduce((min, value) => value < min ? value : min);
+}

--- a/services/seed-backend/src/decision.ts
+++ b/services/seed-backend/src/decision.ts
@@ -4,6 +4,7 @@ export type FundingMode = "initial" | "refill";
 export interface PayoutPolicy {
   initialTarget: bigint;
   refillTarget: bigint;
+  refillTriggerBalance: bigint;
   walletDailyCap: bigint;
   globalDailyCap: bigint;
   lifetimeCapApp: bigint;
@@ -49,6 +50,18 @@ export function planPayout(input: PayoutInputs, policy: PayoutPolicy): PayoutPla
         reason: `refill interval has not elapsed; next eligible at ${new Date(nextEligible).toISOString()}`,
       };
     }
+  }
+
+  if (
+    input.mode === "refill" &&
+    policy.refillTriggerBalance > 0n &&
+    input.currentBalance >= policy.refillTriggerBalance
+  ) {
+    return {
+      status: "skip",
+      amount: 0n,
+      reason: "wallet balance is above refill trigger",
+    };
   }
 
   const target = input.totalFunded === 0n || input.mode === "initial"
@@ -106,6 +119,12 @@ export interface SpendRiskDecision {
   suspicious: boolean;
   state: AllocationState;
   suspiciousCount: number;
+}
+
+export function mostRestrictiveAllocationState(states: AllocationState[]): AllocationState {
+  if (states.includes("blacklisted")) return "blacklisted";
+  if (states.includes("paused")) return "paused";
+  return "active";
 }
 
 export function applySpendRisk(input: SpendRiskInput, policy: RiskPolicy): SpendRiskDecision {

--- a/services/seed-backend/src/github.ts
+++ b/services/seed-backend/src/github.ts
@@ -1,5 +1,3 @@
-import { config } from "./config.js";
-
 export interface GithubValidationResult {
   ok: boolean;
   normalizedUrl?: string;
@@ -43,6 +41,7 @@ export function parseGithubUrl(raw: string): GithubValidationResult {
 export async function validateGithubRepo(rawUrl: string): Promise<GithubValidationResult> {
   const parsed = parseGithubUrl(rawUrl);
   if (!parsed.ok || !parsed.owner || !parsed.repo) return parsed;
+  const { config } = await import("./config.js");
 
   const headers: Record<string, string> = {
     accept: "application/vnd.github+json",

--- a/services/seed-backend/src/github.ts
+++ b/services/seed-backend/src/github.ts
@@ -1,0 +1,98 @@
+import { config } from "./config.js";
+
+export interface GithubValidationResult {
+  ok: boolean;
+  normalizedUrl?: string;
+  owner?: string;
+  repo?: string;
+  reason?: string;
+}
+
+const CODE_EXTENSIONS = new Set([
+  ".rs", ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".java", ".kt", ".swift",
+  ".c", ".cc", ".cpp", ".h", ".hpp", ".cs", ".sol", ".move", ".toml", ".json",
+  ".yaml", ".yml", ".svelte", ".vue",
+]);
+
+export function parseGithubUrl(raw: string): GithubValidationResult {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { ok: false, reason: "github URL is not syntactically valid" };
+  }
+
+  if (url.hostname.toLowerCase() !== "github.com") {
+    return { ok: false, reason: "github URL must use github.com domain" };
+  }
+
+  const [owner, repoRaw] = url.pathname.split("/").filter(Boolean);
+  const repo = repoRaw?.replace(/\.git$/i, "");
+  if (!owner || !repo) {
+    return { ok: false, reason: "github URL must point to owner/repo" };
+  }
+
+  return {
+    ok: true,
+    owner,
+    repo,
+    normalizedUrl: `https://github.com/${owner}/${repo}`,
+  };
+}
+
+export async function validateGithubRepo(rawUrl: string): Promise<GithubValidationResult> {
+  const parsed = parseGithubUrl(rawUrl);
+  if (!parsed.ok || !parsed.owner || !parsed.repo) return parsed;
+
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "user-agent": "vara-agent-network-seed-backend",
+  };
+  if (config.githubToken) headers.authorization = `Bearer ${config.githubToken}`;
+
+  const base = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}`;
+  const repoRes = await fetch(base, { headers });
+  if (repoRes.status === 404) return { ...parsed, ok: false, reason: "github repo does not exist or is private" };
+  if (!repoRes.ok) return { ...parsed, ok: false, reason: `github repo check failed with ${repoRes.status}` };
+
+  const repo = await repoRes.json() as {
+    private?: boolean;
+    size?: number;
+    pushed_at?: string;
+    default_branch?: string;
+  };
+  if (repo.private) return { ...parsed, ok: false, reason: "github repo is private" };
+  if (!repo.size || repo.size <= 0) return { ...parsed, ok: false, reason: "github repo is empty" };
+
+  const pushedAt = repo.pushed_at ? Date.parse(repo.pushed_at) : 0;
+  const recentAfter = Date.now() - config.recentCommitDays * 24 * 60 * 60 * 1000;
+  if (!pushedAt || pushedAt < recentAfter) {
+    return { ...parsed, ok: false, reason: `github repo has no commits in last ${config.recentCommitDays} days` };
+  }
+
+  const branch = encodeURIComponent(repo.default_branch ?? "main");
+  const treeRes = await fetch(`${base}/git/trees/${branch}?recursive=1`, { headers });
+  if (!treeRes.ok) return { ...parsed, ok: false, reason: `github tree check failed with ${treeRes.status}` };
+
+  const tree = await treeRes.json() as {
+    tree?: Array<{ path?: string; type?: string; size?: number }>;
+  };
+  const files = tree.tree?.filter((entry) => entry.type === "blob" && entry.path) ?? [];
+  const hasReadme = files.some((entry) => /^readme(\.|$)/i.test(entry.path!.split("/").pop() ?? ""));
+  if (!hasReadme) return { ...parsed, ok: false, reason: "github repo has no README" };
+
+  const codeFiles = files.filter((entry) => {
+    const path = entry.path!.toLowerCase();
+    return [...CODE_EXTENSIONS].some((ext) => path.endsWith(ext));
+  });
+  if (codeFiles.length < 2) {
+    return { ...parsed, ok: false, reason: "github repo does not contain enough code files" };
+  }
+
+  const totalCodeBytes = codeFiles.reduce((sum, entry) => sum + Number(entry.size ?? 0), 0);
+  if (totalCodeBytes < 1024) {
+    return { ...parsed, ok: false, reason: "github repo looks like a placeholder" };
+  }
+
+  return parsed;
+}

--- a/services/seed-backend/src/indexer-sync.ts
+++ b/services/seed-backend/src/indexer-sync.ts
@@ -1,0 +1,111 @@
+import { config } from "./config.js";
+import { type ApplicationRow, upsertApplicationsFromIndexer } from "./db.js";
+import { log } from "./logger.js";
+
+interface GraphqlApplication {
+  id: string;
+  handle: string;
+  owner: string;
+  githubUrl: string;
+  status: string;
+  seasonId: number;
+  registeredAt: string;
+}
+
+interface ApplicationSyncResult {
+  fetched: number;
+  upserted: number;
+}
+
+const QUERY = `
+  query ApplicationsForSeedBackend($first: Int!, $after: Cursor) {
+    allApplications(first: $first, after: $after, orderBy: REGISTERED_AT_ASC) {
+      nodes {
+        id
+        handle
+        owner
+        githubUrl
+        status
+        seasonId
+        registeredAt
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+export class IndexerApplicationSync {
+  private running = false;
+  private syncRunning = false;
+
+  async start(): Promise<void> {
+    if (!config.applicationSyncEnabled || !config.indexerGraphqlUrl || this.running) return;
+    this.running = true;
+    await this.sync().catch((error) => log.error("application sync failed", error));
+    if (config.applicationSyncIntervalSec > 0) {
+      setInterval(() => {
+        this.sync().catch((error) => log.error("application sync failed", error));
+      }, config.applicationSyncIntervalSec * 1000);
+    }
+  }
+
+  async sync(): Promise<ApplicationSyncResult> {
+    if (!config.applicationSyncEnabled || !config.indexerGraphqlUrl) return { fetched: 0, upserted: 0 };
+    if (this.syncRunning) return { fetched: 0, upserted: 0 };
+    this.syncRunning = true;
+    try {
+      const applications = await fetchApplications();
+      const upserted = await upsertApplicationsFromIndexer(applications);
+      log.info("applications synced from indexer", { fetched: applications.length, upserted });
+      return { fetched: applications.length, upserted };
+    } finally {
+      this.syncRunning = false;
+    }
+  }
+}
+
+async function fetchApplications(): Promise<ApplicationRow[]> {
+  const all: ApplicationRow[] = [];
+  let after: string | null = null;
+  for (;;) {
+    const res = await fetch(config.indexerGraphqlUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: QUERY, variables: { first: 100, after } }),
+    });
+    if (!res.ok) throw new Error(`indexer graphql failed with ${res.status}`);
+    const json = await res.json() as {
+      data?: {
+        allApplications?: {
+          nodes: GraphqlApplication[];
+          pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        };
+      };
+      errors?: Array<{ message: string }>;
+    };
+    if (json.errors?.length) {
+      throw new Error(`indexer graphql error: ${json.errors.map((e) => e.message).join("; ")}`);
+    }
+    const conn = json.data?.allApplications;
+    if (!conn) throw new Error("indexer graphql response missing allApplications");
+    all.push(...conn.nodes.map(mapApplication));
+    if (!conn.pageInfo.hasNextPage) break;
+    after = conn.pageInfo.endCursor;
+  }
+  return all;
+}
+
+function mapApplication(app: GraphqlApplication): ApplicationRow {
+  return {
+    id: app.id.toLowerCase(),
+    handle: app.handle,
+    owner: app.owner.toLowerCase(),
+    github_url: app.githubUrl,
+    status: app.status,
+    season_id: app.seasonId,
+    registered_at: BigInt(app.registeredAt),
+  };
+}

--- a/services/seed-backend/src/logger.ts
+++ b/services/seed-backend/src/logger.ts
@@ -1,0 +1,18 @@
+export const log = {
+  info(message: string, meta?: unknown) {
+    console.log(JSON.stringify({ level: "info", message, ...asMeta(meta) }));
+  },
+  warn(message: string, meta?: unknown) {
+    console.warn(JSON.stringify({ level: "warn", message, ...asMeta(meta) }));
+  },
+  error(message: string, meta?: unknown) {
+    console.error(JSON.stringify({ level: "error", message, ...asMeta(meta) }));
+  },
+};
+
+function asMeta(meta: unknown): Record<string, unknown> {
+  if (meta === undefined) return {};
+  if (meta instanceof Error) return { error: meta.message, stack: meta.stack };
+  if (typeof meta === "object" && meta !== null) return meta as Record<string, unknown>;
+  return { meta };
+}

--- a/services/seed-backend/src/main.ts
+++ b/services/seed-backend/src/main.ts
@@ -29,14 +29,14 @@ app.get("/health", async (_req, res, next) => {
     const db = await pool.query("SELECT 1 AS ok");
     res.json({
       ok: db.rows[0]?.ok === 1,
-      eligibleStatuses: config.eligibleStatuses,
+      fundingEligibility: "any_registered_application",
     });
   } catch (error) {
     next(error);
   }
 });
 
-app.get("/seed/allocations", async (req, res, next) => {
+app.get("/seed/allocations", requireApiKey, async (req, res, next) => {
   try {
     const wallet = typeof req.query.wallet === "string" ? req.query.wallet : undefined;
     res.json({ allocations: await listAllocations(wallet) });
@@ -45,7 +45,7 @@ app.get("/seed/allocations", async (req, res, next) => {
   }
 });
 
-app.get("/seed/allocations/:wallet", async (req, res, next) => {
+app.get("/seed/allocations/:wallet", requireApiKey, async (req, res, next) => {
   try {
     res.json({ allocations: await listAllocations(req.params.wallet) });
   } catch (error) {

--- a/services/seed-backend/src/main.ts
+++ b/services/seed-backend/src/main.ts
@@ -53,6 +53,15 @@ app.get("/seed/allocations/:wallet", async (req, res, next) => {
   }
 });
 
+app.get("/seed/payouts", requireApiKey, async (req, res, next) => {
+  try {
+    const status = typeof req.query.status === "string" ? req.query.status : undefined;
+    res.json({ payouts: await seedService.listPayouts(status) });
+  } catch (error) {
+    next(error);
+  }
+});
+
 app.post("/seed/claim", requireApiKey, async (req, res, next) => {
   try {
     const applicationId = requireApplicationId(req.body);
@@ -75,6 +84,24 @@ app.post("/seed/scan", requireApiKey, async (req, res, next) => {
   try {
     const limit = Number.isInteger(req.body?.limit) ? Number(req.body.limit) : 100;
     res.json({ results: await seedService.scan(Math.max(1, Math.min(limit, 500))) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/seed/payouts/:idempotencyKey/mark-sent", requireApiKey, async (req, res, next) => {
+  try {
+    const txHash = requireString(req.body, "txHash");
+    res.json({ payout: await seedService.markPayoutSent(req.params.idempotencyKey, txHash) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/seed/payouts/:idempotencyKey/cancel", requireApiKey, async (req, res, next) => {
+  try {
+    const reason = requireString(req.body, "reason");
+    res.json({ payout: await seedService.cancelPayout(req.params.idempotencyKey, reason) });
   } catch (error) {
     next(error);
   }
@@ -110,4 +137,13 @@ function requireApplicationId(body: unknown): string {
     throw new Error("applicationId must be a hex ActorId");
   }
   return value;
+}
+
+function requireString(body: unknown, field: string): string {
+  if (!body || typeof body !== "object") throw new Error("request body is required");
+  const value = (body as Record<string, unknown>)[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value.trim();
 }

--- a/services/seed-backend/src/main.ts
+++ b/services/seed-backend/src/main.ts
@@ -1,20 +1,36 @@
 import express from "express";
 import cors from "cors";
-import { config } from "./config.js";
+import { config, validateRuntimeConfig } from "./config.js";
 import { ChainClient } from "./chain.js";
-import { ensureSchema, listAllocations, pool } from "./db.js";
+import { ensureSchema, listAllocations, pool, validateDatabaseSchema } from "./db.js";
 import { SeedService } from "./seed-service.js";
 import { SpendMonitor } from "./monitor.js";
 import { log } from "./logger.js";
+import { IndexerApplicationSync } from "./indexer-sync.js";
 
-await ensureSchema();
+validateRuntimeConfig();
+
+if (config.seedAutoMigrate) {
+  await ensureSchema();
+}
+await validateDatabaseSchema();
 
 const chain = new ChainClient();
 await chain.connect();
 
 const seedService = new SeedService(chain);
+const applicationSync = new IndexerApplicationSync();
+await applicationSync.start();
 const monitor = new SpendMonitor(chain);
 await monitor.start();
+
+if (config.autoClaimIntervalSec > 0) {
+  scheduleRecurring("auto claim scan", config.autoClaimIntervalSec, () => seedService.scan(500));
+}
+
+if (config.autoRefillIntervalSec > 0) {
+  scheduleRecurring("auto refill scan", config.autoRefillIntervalSec, () => seedService.autoRefillScan(500));
+}
 
 const app = express();
 app.use(express.json({ limit: "64kb" }));
@@ -89,6 +105,23 @@ app.post("/seed/scan", requireApiKey, async (req, res, next) => {
   }
 });
 
+app.post("/seed/sync-applications", requireApiKey, async (_req, res, next) => {
+  try {
+    res.json(await applicationSync.sync());
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/seed/refill-scan", requireApiKey, async (req, res, next) => {
+  try {
+    const limit = Number.isInteger(req.body?.limit) ? Number(req.body.limit) : 500;
+    res.json({ results: await seedService.autoRefillScan(Math.max(1, Math.min(limit, 500))) });
+  } catch (error) {
+    next(error);
+  }
+});
+
 app.post("/seed/payouts/:idempotencyKey/mark-sent", requireApiKey, async (req, res, next) => {
   try {
     const txHash = requireString(req.body, "txHash");
@@ -102,6 +135,16 @@ app.post("/seed/payouts/:idempotencyKey/cancel", requireApiKey, async (req, res,
   try {
     const reason = requireString(req.body, "reason");
     res.json({ payout: await seedService.cancelPayout(req.params.idempotencyKey, reason) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/seed/allocations/:wallet/unblacklist", requireApiKey, async (req, res, next) => {
+  try {
+    const reason = requireString(req.body, "reason");
+    const affectedAllocations = await seedService.unblacklistWallet(req.params.wallet, reason);
+    res.json({ affectedAllocations });
   } catch (error) {
     next(error);
   }
@@ -146,4 +189,26 @@ function requireString(body: unknown, field: string): string {
     throw new Error(`${field} must be a non-empty string`);
   }
   return value.trim();
+}
+
+function scheduleRecurring<T>(name: string, intervalSec: number, task: () => Promise<T>): void {
+  let running = false;
+  const run = async () => {
+    if (running) return;
+    running = true;
+    try {
+      const result = await task();
+      if (Array.isArray(result)) {
+        log.info(`${name} completed`, { results: result.length });
+      }
+    } catch (error) {
+      log.error(`${name} failed`, error);
+    } finally {
+      running = false;
+    }
+  };
+  run().catch((error) => log.error(`${name} failed`, error));
+  setInterval(() => {
+    run().catch((error) => log.error(`${name} failed`, error));
+  }, intervalSec * 1000);
 }

--- a/services/seed-backend/src/main.ts
+++ b/services/seed-backend/src/main.ts
@@ -1,0 +1,113 @@
+import express from "express";
+import cors from "cors";
+import { config } from "./config.js";
+import { ChainClient } from "./chain.js";
+import { ensureSchema, listAllocations, pool } from "./db.js";
+import { SeedService } from "./seed-service.js";
+import { SpendMonitor } from "./monitor.js";
+import { log } from "./logger.js";
+
+await ensureSchema();
+
+const chain = new ChainClient();
+await chain.connect();
+
+const seedService = new SeedService(chain);
+const monitor = new SpendMonitor(chain);
+await monitor.start();
+
+const app = express();
+app.use(express.json({ limit: "64kb" }));
+if (config.corsOrigin) {
+  app.use(cors({ origin: config.corsOrigin.split(",").map((s) => s.trim()).filter(Boolean) }));
+} else {
+  app.use(cors());
+}
+
+app.get("/health", async (_req, res, next) => {
+  try {
+    const db = await pool.query("SELECT 1 AS ok");
+    res.json({
+      ok: db.rows[0]?.ok === 1,
+      eligibleStatuses: config.eligibleStatuses,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get("/seed/allocations", async (req, res, next) => {
+  try {
+    const wallet = typeof req.query.wallet === "string" ? req.query.wallet : undefined;
+    res.json({ allocations: await listAllocations(wallet) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get("/seed/allocations/:wallet", async (req, res, next) => {
+  try {
+    res.json({ allocations: await listAllocations(req.params.wallet) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/seed/claim", requireApiKey, async (req, res, next) => {
+  try {
+    const applicationId = requireApplicationId(req.body);
+    res.json(await seedService.claim(applicationId));
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/seed/refill", requireApiKey, async (req, res, next) => {
+  try {
+    const applicationId = requireApplicationId(req.body);
+    res.json(await seedService.refill(applicationId));
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post("/seed/scan", requireApiKey, async (req, res, next) => {
+  try {
+    const limit = Number.isInteger(req.body?.limit) ? Number(req.body.limit) : 100;
+    res.json({ results: await seedService.scan(Math.max(1, Math.min(limit, 500))) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.use((error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  const message = error instanceof Error ? error.message : String(error);
+  log.error("request failed", error);
+  res.status(500).json({ error: message });
+});
+
+app.listen(config.port, () => {
+  log.info("seed backend listening", { port: config.port });
+});
+
+function requireApiKey(req: express.Request, res: express.Response, next: express.NextFunction): void {
+  if (!config.apiKey) {
+    next();
+    return;
+  }
+  const token = req.header("authorization")?.replace(/^Bearer\s+/i, "");
+  if (token !== config.apiKey) {
+    res.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  next();
+}
+
+function requireApplicationId(body: unknown): string {
+  if (!body || typeof body !== "object") throw new Error("request body is required");
+  const value = (body as { applicationId?: unknown }).applicationId;
+  if (typeof value !== "string" || !value.startsWith("0x")) {
+    throw new Error("applicationId must be a hex ActorId");
+  }
+  return value;
+}

--- a/services/seed-backend/src/migrate.ts
+++ b/services/seed-backend/src/migrate.ts
@@ -1,0 +1,45 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pool } from "./db.js";
+import { log } from "./logger.js";
+
+const migrationsDir = join(process.cwd(), "migrations");
+
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS seed_schema_migrations (
+    name text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+  )
+`);
+
+const files = (await readdir(migrationsDir))
+  .filter((file) => file.endsWith(".sql"))
+  .sort();
+
+for (const file of files) {
+  const existing = await pool.query<{ name: string }>(
+    `SELECT name FROM seed_schema_migrations WHERE name = $1`,
+    [file],
+  );
+  if (existing.rows.length > 0) continue;
+
+  const sql = await readFile(join(migrationsDir, file), "utf8");
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(sql);
+    await client.query(
+      `INSERT INTO seed_schema_migrations (name) VALUES ($1)`,
+      [file],
+    );
+    await client.query("COMMIT");
+    log.info("seed migration applied", { file });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+await pool.end();

--- a/services/seed-backend/src/monitor.ts
+++ b/services/seed-backend/src/monitor.ts
@@ -15,7 +15,7 @@ export class SpendMonitor {
   async start(): Promise<void> {
     if (this.running) return;
     this.running = true;
-    await this.guardedTick().catch((error) => log.error("seed monitor initial tick failed", error));
+    this.guardedTick().catch((error) => log.error("seed monitor initial tick failed", error));
     setInterval(() => {
       this.guardedTick().catch((error) => log.error("seed monitor tick failed", error));
     }, config.monitorPollIntervalMs);
@@ -36,13 +36,19 @@ export class SpendMonitor {
     const from = await this.resumePoint(head);
     if (from > head) return;
 
-    const fundedWallets = await this.fundedWallets();
     const allowedRecipients = await listAllowedRecipients();
 
     for (let block = from; block <= head; block++) {
-      const events = await this.chain.readSpendEvents(block, fundedWallets);
+      const fundedWallets = await this.fundedWallets();
+      const taintedPrograms = await this.taintedPrograms();
+      const events = await this.chain.readSpendEvents(block, fundedWallets, taintedPrograms);
       for (const event of events) {
-        await this.recordSpend(event, isAllowedRecipient(event.recipient, allowedRecipients));
+        const allowed = isAllowedRecipient(event.recipient, allowedRecipients);
+        if (event.kind === "tainted_program_value") {
+          await this.recordTaintedProgramSpend(event, allowed);
+        } else {
+          await this.recordSpend(event, allowed);
+        }
       }
       await this.advanceCursor(block);
     }
@@ -92,6 +98,17 @@ export class SpendMonitor {
     return new Set(rows.rows.map((r) => r.wallet.toLowerCase()));
   }
 
+  private async taintedPrograms(): Promise<Set<string>> {
+    const rows = await pool.query<{ program_id: string }>(
+      `
+        SELECT DISTINCT program_id
+        FROM seed_taint_targets
+        WHERE state = 'active'
+      `,
+    );
+    return new Set(rows.rows.map((r) => r.program_id.toLowerCase()));
+  }
+
   private async recordSpend(event: SpendEvent, allowed: boolean): Promise<void> {
     const inserted = await pool.query<{ id: string }>(
       `
@@ -118,13 +135,104 @@ export class SpendMonitor {
     );
     if (inserted.rows.length === 0) return;
 
-    if (allowed) return;
+    if (allowed) {
+      if (event.kind === "gear_value") await this.recordFundedWalletTaint(event);
+      return;
+    }
 
     await this.applySuspicion(event);
   }
 
+  private async recordTaintedProgramSpend(event: SpendEvent, allowed: boolean): Promise<void> {
+    const sourceProgram = event.sourceProgram?.toLowerCase() ?? event.wallet.toLowerCase();
+    const links = await pool.query<{ source_wallet: string; source_application_id: string }>(
+      `
+        SELECT source_wallet, source_application_id
+        FROM seed_taint_targets
+        WHERE program_id = $1 AND state = 'active'
+      `,
+      [sourceProgram],
+    );
+
+    for (const link of links.rows) {
+      const attributed: SpendEvent = {
+        ...event,
+        id: `${event.id}:${link.source_wallet}:${link.source_application_id}`,
+        wallet: link.source_wallet,
+        sourceProgram,
+      };
+      await this.recordSpend(attributed, allowed);
+      if (allowed) {
+        await this.recordTaintTarget({
+          sourceWallet: link.source_wallet,
+          sourceApplicationId: link.source_application_id,
+          programId: event.recipient,
+          amountRaw: event.amountRaw,
+          event,
+        });
+      }
+    }
+  }
+
+  private async recordFundedWalletTaint(event: SpendEvent): Promise<void> {
+    const rows = await pool.query<{ application_id: string }>(
+      `
+        SELECT application_id
+        FROM seed_allocations
+        WHERE wallet = $1
+          AND total_funded_raw > 0
+          AND state <> 'blacklisted'
+      `,
+      [event.wallet],
+    );
+
+    for (const row of rows.rows) {
+      await this.recordTaintTarget({
+        sourceWallet: event.wallet,
+        sourceApplicationId: row.application_id,
+        programId: event.recipient,
+        amountRaw: event.amountRaw,
+        event,
+      });
+    }
+  }
+
+  private async recordTaintTarget(input: {
+    sourceWallet: string;
+    sourceApplicationId: string;
+    programId: string;
+    amountRaw: bigint;
+    event: SpendEvent;
+  }): Promise<void> {
+    await pool.query(
+      `
+        INSERT INTO seed_taint_targets (
+          source_wallet, source_application_id, program_id, amount_raw,
+          first_seen_block, last_seen_block, last_event_id
+        )
+        VALUES ($1, $2, $3, $4, $5, $5, $6)
+        ON CONFLICT (source_wallet, source_application_id, program_id) DO UPDATE SET
+          amount_raw = seed_taint_targets.amount_raw + EXCLUDED.amount_raw,
+          last_seen_block = EXCLUDED.last_seen_block,
+          last_event_id = EXCLUDED.last_event_id,
+          state = 'active',
+          updated_at = now()
+      `,
+      [
+        input.sourceWallet.toLowerCase(),
+        input.sourceApplicationId.toLowerCase(),
+        input.programId.toLowerCase(),
+        input.amountRaw.toString(),
+        input.event.substrateBlockNumber,
+        input.event.id,
+      ],
+    );
+  }
+
   private async applySuspicion(event: SpendEvent): Promise<void> {
-    const reason = `${event.kind} to non-hackathon recipient ${event.recipient}`;
+    const reason = event.kind === "tainted_program_value" && event.sourceProgram
+      ? `${event.kind} from tainted program ${event.sourceProgram} to non-hackathon recipient ${event.recipient}`
+      : `${event.kind} to non-hackathon recipient ${event.recipient}`;
 
     const rows = await pool.query<{ wallet: string; application_id: string; suspicious_count: number; state: string }>(
       `

--- a/services/seed-backend/src/monitor.ts
+++ b/services/seed-backend/src/monitor.ts
@@ -8,16 +8,27 @@ const SUSPICIOUS_PAUSE_THRESHOLD = varaToPlanck(config.suspiciousPauseThresholdV
 
 export class SpendMonitor {
   private running = false;
+  private tickRunning = false;
 
   constructor(private readonly chain: ChainClient) {}
 
   async start(): Promise<void> {
     if (this.running) return;
     this.running = true;
-    await this.tick().catch((error) => log.error("seed monitor initial tick failed", error));
+    await this.guardedTick().catch((error) => log.error("seed monitor initial tick failed", error));
     setInterval(() => {
-      this.tick().catch((error) => log.error("seed monitor tick failed", error));
+      this.guardedTick().catch((error) => log.error("seed monitor tick failed", error));
     }, config.monitorPollIntervalMs);
+  }
+
+  private async guardedTick(): Promise<void> {
+    if (this.tickRunning) return;
+    this.tickRunning = true;
+    try {
+      await this.tick();
+    } finally {
+      this.tickRunning = false;
+    }
   }
 
   private async tick(): Promise<void> {

--- a/services/seed-backend/src/monitor.ts
+++ b/services/seed-backend/src/monitor.ts
@@ -1,0 +1,151 @@
+import { config, varaToPlanck } from "./config.js";
+import { ChainClient, type SpendEvent } from "./chain.js";
+import { listAllowedRecipients, pool, recordAudit } from "./db.js";
+import { log } from "./logger.js";
+
+const SUSPICIOUS_PAUSE_THRESHOLD = varaToPlanck(config.suspiciousPauseThresholdVara);
+
+export class SpendMonitor {
+  private running = false;
+
+  constructor(private readonly chain: ChainClient) {}
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    await this.tick().catch((error) => log.error("seed monitor initial tick failed", error));
+    setInterval(() => {
+      this.tick().catch((error) => log.error("seed monitor tick failed", error));
+    }, config.monitorPollIntervalMs);
+  }
+
+  private async tick(): Promise<void> {
+    const head = await this.chain.finalizedHeight();
+    let from = await this.resumePoint();
+    if (from > head) return;
+
+    const fundedWallets = await this.fundedWallets();
+    const allowedRecipients = await listAllowedRecipients();
+
+    for (let block = from; block <= head; block++) {
+      const events = await this.chain.readSpendEvents(block, fundedWallets);
+      for (const event of events) {
+        await this.recordSpend(event, allowedRecipients.has(event.recipient));
+      }
+      await this.advanceCursor(block);
+    }
+  }
+
+  private async resumePoint(): Promise<number> {
+    const rows = await pool.query<{ last_processed_block: number }>(
+      `SELECT last_processed_block FROM seed_monitor_cursor WHERE id = 'main'`,
+    );
+    if (rows.rows[0]) return rows.rows[0].last_processed_block + 1;
+    await pool.query(
+      `
+        INSERT INTO seed_monitor_cursor (id, last_processed_block)
+        VALUES ('main', $1)
+        ON CONFLICT (id) DO NOTHING
+      `,
+      [Math.max(0, config.monitorStartBlock - 1)],
+    );
+    return config.monitorStartBlock;
+  }
+
+  private async advanceCursor(blockNumber: number): Promise<void> {
+    await pool.query(
+      `
+        INSERT INTO seed_monitor_cursor (id, last_processed_block, updated_at)
+        VALUES ('main', $1, now())
+        ON CONFLICT (id) DO UPDATE SET
+          last_processed_block = EXCLUDED.last_processed_block,
+          updated_at = now()
+      `,
+      [blockNumber],
+    );
+  }
+
+  private async fundedWallets(): Promise<Set<string>> {
+    const rows = await pool.query<{ wallet: string }>(
+      `
+        SELECT DISTINCT wallet
+        FROM seed_allocations
+        WHERE total_funded_raw > 0
+          AND state <> 'blacklisted'
+      `,
+    );
+    return new Set(rows.rows.map((r) => r.wallet.toLowerCase()));
+  }
+
+  private async recordSpend(event: SpendEvent, allowed: boolean): Promise<void> {
+    const inserted = await pool.query<{ id: string }>(
+      `
+        INSERT INTO seed_spend_events (
+          id, wallet, recipient, amount_raw, kind, allowed,
+          substrate_block_number, substrate_block_ts, extrinsic_idx, event_idx
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ON CONFLICT (id) DO NOTHING
+        RETURNING id
+      `,
+      [
+        event.id,
+        event.wallet,
+        event.recipient,
+        event.amountRaw.toString(),
+        event.kind,
+        allowed,
+        event.substrateBlockNumber,
+        event.substrateBlockTs,
+        event.extrinsicIdx,
+        event.eventIdx,
+      ],
+    );
+    if (inserted.rows.length === 0) return;
+
+    if (allowed) return;
+
+    await this.applySuspicion(event);
+  }
+
+  private async applySuspicion(event: SpendEvent): Promise<void> {
+    const shouldPause = event.amountRaw >= SUSPICIOUS_PAUSE_THRESHOLD;
+    const reason = `${event.kind} to non-hackathon recipient ${event.recipient}`;
+
+    const rows = await pool.query<{ wallet: string; application_id: string; suspicious_count: number; state: string }>(
+      `
+        UPDATE seed_allocations
+        SET suspicious_count = suspicious_count + 1,
+            risk_score = risk_score + 1,
+            state = CASE
+              WHEN suspicious_count + 1 >= $2 THEN 'blacklisted'
+              WHEN $3::boolean THEN 'paused'
+              ELSE state
+            END,
+            last_reason = $4,
+            updated_at = now()
+        WHERE wallet = $1
+          AND state <> 'blacklisted'
+        RETURNING wallet, application_id, suspicious_count, state
+      `,
+      [event.wallet, config.blacklistThreshold, shouldPause, reason],
+    );
+
+    for (const row of rows.rows) {
+      await recordAudit(
+        row.state === "blacklisted" ? "error" : "warn",
+        "suspicious seed spend detected",
+        {
+          spendEventId: event.id,
+          recipient: event.recipient,
+          amountRaw: event.amountRaw.toString(),
+          kind: event.kind,
+          state: row.state,
+          suspiciousCount: row.suspicious_count,
+        },
+        row.wallet,
+        row.application_id,
+      );
+    }
+  }
+}

--- a/services/seed-backend/src/monitor.ts
+++ b/services/seed-backend/src/monitor.ts
@@ -2,6 +2,7 @@ import { config, varaToPlanck } from "./config.js";
 import { ChainClient, type SpendEvent } from "./chain.js";
 import { listAllowedRecipients, pool, recordAudit } from "./db.js";
 import { log } from "./logger.js";
+import { applySpendRisk, isAllowedRecipient } from "./decision.js";
 
 const SUSPICIOUS_PAUSE_THRESHOLD = varaToPlanck(config.suspiciousPauseThresholdVara);
 
@@ -21,7 +22,7 @@ export class SpendMonitor {
 
   private async tick(): Promise<void> {
     const head = await this.chain.finalizedHeight();
-    let from = await this.resumePoint();
+    const from = await this.resumePoint(head);
     if (from > head) return;
 
     const fundedWallets = await this.fundedWallets();
@@ -30,26 +31,29 @@ export class SpendMonitor {
     for (let block = from; block <= head; block++) {
       const events = await this.chain.readSpendEvents(block, fundedWallets);
       for (const event of events) {
-        await this.recordSpend(event, allowedRecipients.has(event.recipient));
+        await this.recordSpend(event, isAllowedRecipient(event.recipient, allowedRecipients));
       }
       await this.advanceCursor(block);
     }
   }
 
-  private async resumePoint(): Promise<number> {
+  private async resumePoint(finalizedHead: number): Promise<number> {
     const rows = await pool.query<{ last_processed_block: number }>(
       `SELECT last_processed_block FROM seed_monitor_cursor WHERE id = 'main'`,
     );
     if (rows.rows[0]) return rows.rows[0].last_processed_block + 1;
+    const startBlock = config.monitorStartBlock === "latest"
+      ? finalizedHead
+      : config.monitorStartBlock;
     await pool.query(
       `
         INSERT INTO seed_monitor_cursor (id, last_processed_block)
         VALUES ('main', $1)
         ON CONFLICT (id) DO NOTHING
       `,
-      [Math.max(0, config.monitorStartBlock - 1)],
+      [Math.max(0, startBlock - 1)],
     );
-    return config.monitorStartBlock;
+    return startBlock;
   }
 
   private async advanceCursor(blockNumber: number): Promise<void> {
@@ -109,26 +113,38 @@ export class SpendMonitor {
   }
 
   private async applySuspicion(event: SpendEvent): Promise<void> {
-    const shouldPause = event.amountRaw >= SUSPICIOUS_PAUSE_THRESHOLD;
     const reason = `${event.kind} to non-hackathon recipient ${event.recipient}`;
 
     const rows = await pool.query<{ wallet: string; application_id: string; suspicious_count: number; state: string }>(
       `
-        UPDATE seed_allocations
-        SET suspicious_count = suspicious_count + 1,
+        UPDATE seed_allocations AS a
+        SET suspicious_count = d.next_suspicious_count,
             risk_score = risk_score + 1,
-            state = CASE
-              WHEN suspicious_count + 1 >= $2 THEN 'blacklisted'
-              WHEN $3::boolean THEN 'paused'
-              ELSE state
-            END,
+            state = d.next_state,
             last_reason = $4,
             updated_at = now()
+        FROM (
+          SELECT id,
+                 suspicious_count + 1 AS next_suspicious_count,
+                 CASE
+                   WHEN suspicious_count + 1 >= $2 THEN 'blacklisted'
+                   WHEN $3::numeric >= $5::numeric THEN 'paused'
+                   ELSE state
+                 END AS next_state
+          FROM seed_allocations
+          WHERE wallet = $1 AND state <> 'blacklisted'
+        ) d
         WHERE wallet = $1
-          AND state <> 'blacklisted'
-        RETURNING wallet, application_id, suspicious_count, state
+          AND a.id = d.id
+        RETURNING wallet, application_id, a.suspicious_count, a.state
       `,
-      [event.wallet, config.blacklistThreshold, shouldPause, reason],
+      [
+        event.wallet,
+        config.blacklistThreshold,
+        event.amountRaw.toString(),
+        reason,
+        SUSPICIOUS_PAUSE_THRESHOLD.toString(),
+      ],
     );
 
     for (const row of rows.rows) {
@@ -149,3 +165,5 @@ export class SpendMonitor {
     }
   }
 }
+
+export const spendRiskForTest = applySpendRisk;

--- a/services/seed-backend/src/payout-key.test.ts
+++ b/services/seed-backend/src/payout-key.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { payoutAttemptKey, payoutBaseKey } from "./payout-key.js";
+
+test("payoutBaseKey keeps first initial payout key stable", () => {
+  assert.equal(payoutBaseKey("initial", "0xwallet", "0xapp"), "initial:0xwallet:0xapp");
+});
+
+test("payoutBaseKey scopes refill key by UTC date", () => {
+  const key = payoutBaseKey("refill", "0xwallet", "0xapp", new Date("2026-05-05T23:59:00.000Z"));
+  assert.equal(key, "refill:0xwallet:0xapp:2026-05-05");
+});
+
+test("payoutAttemptKey uses base key for first attempt and suffix for retries", () => {
+  assert.equal(payoutAttemptKey("refill:0xwallet:0xapp:2026-05-05", 0), "refill:0xwallet:0xapp:2026-05-05");
+  assert.equal(
+    payoutAttemptKey("refill:0xwallet:0xapp:2026-05-05", 1),
+    "refill:0xwallet:0xapp:2026-05-05:attempt-2",
+  );
+});

--- a/services/seed-backend/src/payout-key.ts
+++ b/services/seed-backend/src/payout-key.ts
@@ -1,0 +1,20 @@
+import type { FundingMode } from "./decision.js";
+
+export function payoutBaseKey(
+  mode: FundingMode,
+  wallet: string,
+  applicationId: string,
+  now: Date = new Date(),
+): string {
+  if (mode === "initial") return `initial:${wallet}:${applicationId}`;
+  return `refill:${wallet}:${applicationId}:${now.toISOString().slice(0, 10)}`;
+}
+
+export function payoutAttemptKey(baseKey: string, existingAttemptCount: number): string {
+  if (existingAttemptCount <= 0) return baseKey;
+  return `${baseKey}:attempt-${existingAttemptCount + 1}`;
+}
+
+export function payoutBaseKeyLike(baseKey: string): string {
+  return `${baseKey}:attempt-%`;
+}

--- a/services/seed-backend/src/seed-service.ts
+++ b/services/seed-backend/src/seed-service.ts
@@ -9,9 +9,10 @@ import {
   getAllocationForUpdate,
   getEligibleApplication,
   getPayoutByKey,
+  inheritWalletBlockForUpdate,
   listAllocations,
-  listEligibleApplications,
   listPayouts,
+  listUnfundedApplications,
   recordAudit,
   upsertAllocation,
 } from "./db.js";
@@ -24,6 +25,7 @@ import { payoutAttemptKey, payoutBaseKey, payoutBaseKeyLike } from "./payout-key
 
 const INITIAL_TARGET = varaToPlanck(config.initialTargetVara);
 const REFILL_TARGET = varaToPlanck(config.refillTargetVara);
+const REFILL_TRIGGER_BALANCE = varaToPlanck(config.refillTriggerBalanceVara);
 const DAILY_CAP = varaToPlanck(config.maxDailyRefillVara);
 const GLOBAL_DAILY_CAP = varaToPlanck(config.globalDailyPayoutLimitVara);
 const LIFETIME_CAP_APP = varaToPlanck(config.lifetimeCapAppVara);
@@ -33,6 +35,7 @@ const LIFETIME_CAP_REPO = varaToPlanck(config.lifetimeCapRepoVara);
 const PAYOUT_POLICY: PayoutPolicy = {
   initialTarget: INITIAL_TARGET,
   refillTarget: REFILL_TARGET,
+  refillTriggerBalance: REFILL_TRIGGER_BALANCE,
   walletDailyCap: DAILY_CAP,
   globalDailyCap: GLOBAL_DAILY_CAP,
   lifetimeCapApp: LIFETIME_CAP_APP,
@@ -54,17 +57,31 @@ export class SeedService {
   }
 
   async scan(limit = 100): Promise<FundingDecision[]> {
-    const apps = await listEligibleApplications(limit);
+    const apps = await listUnfundedApplications(limit);
     const results: FundingDecision[] = [];
     for (const app of apps) {
       try {
-        const allocation = (await listAllocations(app.owner)).find(
-          (row) => row.application_id === app.id.toLowerCase(),
-        );
-        if (allocation && BigInt(allocation.total_funded_raw) > 0n) continue;
         results.push(await this.fundApplication(app, "initial"));
       } catch (error) {
         log.warn("seed scan failed for app", { app: app.id, error: String(error) });
+      }
+    }
+    return results;
+  }
+
+  async autoRefillScan(limit = 500): Promise<FundingDecision[]> {
+    const allocations = await listAllocations();
+    const results: FundingDecision[] = [];
+    for (const allocation of allocations.slice(0, limit)) {
+      if (allocation.state !== "active" || BigInt(allocation.total_funded_raw) <= 0n) continue;
+      try {
+        results.push(await this.refill(allocation.application_id));
+      } catch (error) {
+        log.warn("auto refill failed", {
+          wallet: allocation.wallet,
+          applicationId: allocation.application_id,
+          error: String(error),
+        });
       }
     }
     return results;
@@ -122,6 +139,31 @@ export class SeedService {
     return updated;
   }
 
+  async unblacklistWallet(walletInput: string, reason: string): Promise<number> {
+    const wallet = requireAddress(walletInput, "wallet");
+    const rows = await pool.query<{ application_id: string }>(
+      `
+        UPDATE seed_allocations
+        SET state = 'active',
+            suspicious_count = 0,
+            risk_score = 0,
+            last_reason = $2,
+            updated_at = now()
+        WHERE wallet = $1 AND state IN ('paused', 'blacklisted')
+        RETURNING application_id
+      `,
+      [wallet, `manual unblock: ${reason}`],
+    );
+
+    await recordAudit(
+      "warn",
+      "seed wallet manually unblocked",
+      { reason, affectedAllocations: rows.rows.length },
+      wallet,
+    );
+    return rows.rows.length;
+  }
+
   private async fund(applicationId: string, mode: "initial" | "refill"): Promise<FundingDecision> {
     const app = await getEligibleApplication(applicationId);
     if (!app) {
@@ -171,6 +213,7 @@ export class SeedService {
       if (!allocation) throw new Error("allocation row disappeared after upsert");
 
       await resetDailyWindowIfNeeded(client, wallet);
+      await inheritWalletBlockForUpdate(client, wallet, applicationId);
       const fresh = await getAllocationForUpdate(client, wallet, applicationId);
       if (!fresh) throw new Error("allocation row disappeared after daily reset");
 
@@ -230,7 +273,7 @@ export class SeedService {
       }
 
       const baseKey = payoutBaseKey(mode, wallet, applicationId);
-      const blockingPayout = await getBlockingPayout(client, baseKey);
+      const blockingPayout = await getBlockingPayout(client, baseKey, mode);
       if (blockingPayout) {
         await client.query("COMMIT");
         return {
@@ -356,24 +399,40 @@ async function refillActivityCount(
   applicationId: string,
   since: Date,
 ): Promise<number> {
-  const rows = await client.query<{ count: string }>(
-    `
-      SELECT (
-        SELECT count(*)::int
+  let interactionsCount = 0;
+  const hasInteractions = await relationExists(client, "interactions");
+  if (hasInteractions) {
+    const rows = await client.query<{ count: string }>(
+      `
+        SELECT count(*)::text AS count
         FROM interactions
         WHERE substrate_block_ts >= $3
           AND (caller = $1 OR caller = $2 OR callee = $2)
-      ) + (
-        SELECT count(*)::int
-        FROM seed_spend_events
-        WHERE substrate_block_ts >= $4
-          AND wallet = $1
-          AND allowed = true
-      ) AS count
+      `,
+      [wallet, applicationId, since.getTime().toString()],
+    );
+    interactionsCount = Number(rows.rows[0]?.count ?? 0);
+  }
+
+  const spendRows = await client.query<{ count: string }>(
+    `
+      SELECT count(*)::text AS count
+      FROM seed_spend_events
+      WHERE substrate_block_ts >= $2
+        AND wallet = $1
+        AND allowed = true
     `,
-    [wallet, applicationId, since.getTime().toString(), since],
+    [wallet, since],
   );
-  return Number(rows.rows[0]?.count ?? 0);
+  return interactionsCount + Number(spendRows.rows[0]?.count ?? 0);
+}
+
+async function relationExists(client: pg.PoolClient, tableName: string): Promise<boolean> {
+  const rows = await client.query<{ exists: boolean }>(
+    `SELECT to_regclass($1) IS NOT NULL AS exists`,
+    [`public.${tableName}`],
+  );
+  return rows.rows[0]?.exists ?? false;
 }
 
 type PayoutSumScope =
@@ -423,18 +482,23 @@ interface PayoutRow {
   tx_hash: string | null;
 }
 
-async function getBlockingPayout(client: pg.PoolClient, baseKey: string): Promise<PayoutRow | null> {
+async function getBlockingPayout(
+  client: pg.PoolClient,
+  baseKey: string,
+  mode: "initial" | "refill",
+): Promise<PayoutRow | null> {
+  const statuses = mode === "initial" ? ["PENDING", "SENT"] : ["PENDING"];
   const rows = await client.query<PayoutRow>(
     `
       SELECT status, amount_raw::text, tx_hash
       FROM seed_payouts
       WHERE (idempotency_key = $1 OR idempotency_key LIKE $2)
-        AND status IN ('PENDING', 'SENT')
+        AND status = ANY($3::text[])
       ORDER BY created_at DESC
       LIMIT 1
       FOR UPDATE
     `,
-    [baseKey, payoutBaseKeyLike(baseKey)],
+    [baseKey, payoutBaseKeyLike(baseKey), statuses],
   );
   return rows.rows[0] ?? null;
 }

--- a/services/seed-backend/src/seed-service.ts
+++ b/services/seed-backend/src/seed-service.ts
@@ -4,21 +4,42 @@ import {
   pool,
   type ApplicationRow,
   type FundingDecision,
+  type PayoutRow as DbPayoutRow,
+  findAllocation,
   getAllocationForUpdate,
   getEligibleApplication,
+  getPayoutByKey,
   listAllocations,
   listEligibleApplications,
+  listPayouts,
   recordAudit,
   upsertAllocation,
 } from "./db.js";
-import { validateGithubRepo } from "./github.js";
+import { parseGithubUrl, validateGithubRepo } from "./github.js";
 import { ChainClient } from "./chain.js";
 import { requireAddress } from "./address.js";
 import { log } from "./logger.js";
+import { planPayout, type PayoutPolicy } from "./decision.js";
 
 const INITIAL_TARGET = varaToPlanck(config.initialTargetVara);
 const REFILL_TARGET = varaToPlanck(config.refillTargetVara);
 const DAILY_CAP = varaToPlanck(config.maxDailyRefillVara);
+const GLOBAL_DAILY_CAP = varaToPlanck(config.globalDailyPayoutLimitVara);
+const LIFETIME_CAP_APP = varaToPlanck(config.lifetimeCapAppVara);
+const LIFETIME_CAP_WALLET = varaToPlanck(config.lifetimeCapWalletVara);
+const LIFETIME_CAP_GITHUB = varaToPlanck(config.lifetimeCapGithubVara);
+const LIFETIME_CAP_REPO = varaToPlanck(config.lifetimeCapRepoVara);
+const PAYOUT_POLICY: PayoutPolicy = {
+  initialTarget: INITIAL_TARGET,
+  refillTarget: REFILL_TARGET,
+  walletDailyCap: DAILY_CAP,
+  globalDailyCap: GLOBAL_DAILY_CAP,
+  lifetimeCapApp: LIFETIME_CAP_APP,
+  lifetimeCapWallet: LIFETIME_CAP_WALLET,
+  lifetimeCapGithub: LIFETIME_CAP_GITHUB,
+  lifetimeCapRepo: LIFETIME_CAP_REPO,
+  minRefillIntervalMs: config.minRefillIntervalSec * 1000,
+};
 
 export class SeedService {
   constructor(private readonly chain: ChainClient) {}
@@ -48,6 +69,58 @@ export class SeedService {
     return results;
   }
 
+  async listPayouts(status?: string): Promise<DbPayoutRow[]> {
+    return listPayouts(status);
+  }
+
+  async markPayoutSent(idempotencyKey: string, txHash: string): Promise<DbPayoutRow> {
+    const payout = await getPayoutByKey(idempotencyKey);
+    if (!payout) throw new Error("payout not found");
+    if (payout.status !== "PENDING") throw new Error(`payout is ${payout.status}, expected PENDING`);
+    await markPayoutSent(
+      payout.idempotency_key,
+      payout.wallet,
+      payout.application_id,
+      BigInt(payout.amount_raw),
+      txHash,
+      payout.reason,
+    );
+    const updated = await getPayoutByKey(idempotencyKey);
+    if (!updated) throw new Error("payout disappeared after mark-sent");
+    await recordAudit(
+      "info",
+      "pending seed payout reconciled as sent",
+      { idempotencyKey, txHash },
+      updated.wallet,
+      updated.application_id,
+    );
+    return updated;
+  }
+
+  async cancelPayout(idempotencyKey: string, reason: string): Promise<DbPayoutRow> {
+    const payout = await getPayoutByKey(idempotencyKey);
+    if (!payout) throw new Error("payout not found");
+    if (payout.status !== "PENDING") throw new Error(`payout is ${payout.status}, expected PENDING`);
+    await pool.query(
+      `
+        UPDATE seed_payouts
+        SET status = 'CANCELLED', error = $2, updated_at = now()
+        WHERE idempotency_key = $1 AND status = 'PENDING'
+      `,
+      [idempotencyKey, reason],
+    );
+    const updated = await getPayoutByKey(idempotencyKey);
+    if (!updated) throw new Error("payout disappeared after cancellation");
+    await recordAudit(
+      "warn",
+      "pending seed payout cancelled",
+      { idempotencyKey, reason },
+      updated.wallet,
+      updated.application_id,
+    );
+    return updated;
+  }
+
   private async fund(applicationId: string, mode: "initial" | "refill"): Promise<FundingDecision> {
     const app = await getEligibleApplication(applicationId);
     if (!app) {
@@ -66,9 +139,9 @@ export class SeedService {
     const wallet = requireAddress(app.owner, "application owner");
     const applicationId = requireAddress(app.id, "application id");
 
-    const github = await validateGithubRepo(app.github_url);
+    const github = await this.githubCheck(app, wallet, applicationId);
     if (!github.ok) {
-      await upsertAllocation(app, false);
+      await upsertAllocation(app, false, github.owner ?? null, github.repo ?? null);
       await recordAudit("warn", "github validation failed", { reason: github.reason }, wallet, applicationId);
       return {
         status: "skipped",
@@ -79,83 +152,174 @@ export class SeedService {
       };
     }
 
-    await upsertAllocation(app, true);
+    if (!github.owner || !github.repo) {
+      throw new Error("github validation succeeded without normalized owner/repo");
+    }
+
+    await upsertAllocation(app, true, github.owner, github.repo);
 
     const client = await pool.connect();
+    let pending:
+      | { idempotencyKey: string; amount: bigint; reason: string; githubOwner: string; githubRepo: string }
+      | null = null;
     try {
       await client.query("BEGIN");
+      await client.query("SELECT pg_advisory_xact_lock(hashtext('seed-payout-global'))");
       await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [wallet]);
       const allocation = await getAllocationForUpdate(client, wallet, applicationId);
       if (!allocation) throw new Error("allocation row disappeared after upsert");
 
-      if (allocation.state === "blacklisted" || allocation.state === "paused") {
+      await resetDailyWindowIfNeeded(client, wallet);
+      const fresh = await getAllocationForUpdate(client, wallet, applicationId);
+      if (!fresh) throw new Error("allocation row disappeared after daily reset");
+
+      const now = Date.now();
+      const currentBalance = await this.chain.balanceOf(wallet);
+      const totalFunded = BigInt(fresh.total_funded_raw);
+      const dailyFunded = await dailyFundedForWallet(client, wallet);
+      const globalDailyFunded = await payoutSum(client, "global_daily");
+      const appLifetimeFunded = await payoutSum(client, "app_lifetime", { applicationId });
+      const walletLifetimeFunded = await payoutSum(client, "wallet_lifetime", { wallet });
+      const githubLifetimeFunded = await payoutSum(client, "github_lifetime", { githubOwner: github.owner });
+      const repoLifetimeFunded = await payoutSum(client, "repo_lifetime", {
+        githubOwner: github.owner,
+        githubRepo: github.repo,
+      });
+      const plan = planPayout(
+        {
+          mode,
+          state: fresh.state,
+          nowMs: now,
+          currentBalance,
+          totalFunded,
+          walletDailyFunded: dailyFunded,
+          globalDailyFunded,
+          appLifetimeFunded,
+          walletLifetimeFunded,
+          githubLifetimeFunded,
+          repoLifetimeFunded,
+          lastFundedAtMs: fresh.last_funded_at?.getTime() ?? null,
+        },
+        PAYOUT_POLICY,
+      );
+
+      if (plan.status !== "pay") {
         await client.query("COMMIT");
         return {
-          status: allocation.state,
+          status: plan.status === "skip" ? "skipped" : plan.status,
           applicationId,
           wallet,
           amountRaw: "0",
-          reason: allocation.last_reason ?? `allocation is ${allocation.state}`,
+          reason: fresh.last_reason && plan.status !== "skip" ? fresh.last_reason : plan.reason,
         };
       }
 
-      const now = Date.now();
-      if (mode === "refill" && allocation.last_funded_at) {
-        const next = allocation.last_funded_at.getTime() + config.minRefillIntervalSec * 1000;
-        if (now < next) {
+      if (mode === "refill" && config.minRefillActivityEvents > 0 && fresh.last_funded_at) {
+        const activityCount = await refillActivityCount(client, wallet, applicationId, fresh.last_funded_at);
+        if (activityCount < config.minRefillActivityEvents) {
           await client.query("COMMIT");
           return {
             status: "skipped",
             applicationId,
             wallet,
             amountRaw: "0",
-            reason: `refill interval has not elapsed; next eligible at ${new Date(next).toISOString()}`,
+            reason: `not enough meaningful activity since last funding: ${activityCount}/${config.minRefillActivityEvents}`,
           };
         }
       }
 
-      await resetDailyWindowIfNeeded(client, wallet);
-      const fresh = await getAllocationForUpdate(client, wallet, applicationId);
-      if (!fresh) throw new Error("allocation row disappeared after daily reset");
-
-      const currentBalance = await this.chain.balanceOf(wallet);
-      const totalFunded = BigInt(fresh.total_funded_raw);
-      const dailyFunded = await dailyFundedForWallet(client, wallet);
-      const target = totalFunded === 0n || mode === "initial" ? INITIAL_TARGET : REFILL_TARGET;
-      const needed = target > currentBalance ? target - currentBalance : 0n;
-      const dailyLeft = DAILY_CAP > dailyFunded ? DAILY_CAP - dailyFunded : 0n;
-      const amount = minBigInt(needed, dailyLeft);
-
-      if (amount <= 0n) {
+      const idempotencyKey = makePayoutKey(mode, wallet, applicationId);
+      const existing = await getPayout(client, idempotencyKey);
+      if (existing) {
         await client.query("COMMIT");
         return {
-          status: "skipped",
+          status: existing.status === "SENT" ? "funded" : existing.status === "PENDING" ? "pending" : "skipped",
           applicationId,
           wallet,
-          amountRaw: "0",
-          reason: needed <= 0n ? "wallet balance is already at target" : "daily funding cap reached",
+          amountRaw: existing.amount_raw,
+          reason: `payout is already ${existing.status.toLowerCase()}`,
+          txHash: existing.tx_hash ?? undefined,
         };
       }
 
-      const txHash = await this.chain.transfer(wallet, amount);
-      await recordFunding(client, wallet, applicationId, amount, txHash, mode);
-      await client.query("COMMIT");
-
-      await recordAudit("info", "seed funds transferred", { amountRaw: amount.toString(), txHash, mode }, wallet, applicationId);
-      return {
-        status: "funded",
-        applicationId,
+      await createPendingPayout(client, {
+        idempotencyKey,
         wallet,
-        amountRaw: amount.toString(),
+        applicationId,
+        githubOwner: github.owner,
+        githubRepo: github.repo,
+        amount: plan.amount,
         reason: mode,
-        txHash,
-      };
+      });
+      await client.query("COMMIT");
+      pending = { idempotencyKey, amount: plan.amount, reason: mode, githubOwner: github.owner, githubRepo: github.repo };
     } catch (error) {
       await client.query("ROLLBACK");
       throw error;
     } finally {
       client.release();
     }
+
+    if (!pending) throw new Error("pending payout was not created");
+
+    try {
+      const txHash = await this.chain.transfer(wallet, pending.amount);
+      await markPayoutSent(
+        pending.idempotencyKey,
+        wallet,
+        applicationId,
+        pending.amount,
+        txHash,
+        pending.reason,
+      );
+      await recordAudit("info", "seed funds transferred", { amountRaw: pending.amount.toString(), txHash, mode }, wallet, applicationId);
+      return {
+        status: "funded",
+        applicationId,
+        wallet,
+        amountRaw: pending.amount.toString(),
+        reason: mode,
+        txHash,
+      };
+    } catch (error) {
+      await recordAudit(
+        "error",
+        "seed payout left pending after transfer failure",
+        {
+          idempotencyKey: pending.idempotencyKey,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        wallet,
+        applicationId,
+      );
+      throw error;
+    }
+  }
+
+  private async githubCheck(
+    app: ApplicationRow,
+    wallet: string,
+    applicationId: string,
+  ): Promise<ReturnType<typeof parseGithubUrl>> {
+    const parsed = parseGithubUrl(app.github_url);
+    const allocation = await findAllocation(wallet, applicationId);
+    const checkedAt = allocation?.github_checked_at?.getTime() ?? 0;
+    const fresh = checkedAt > 0 && Date.now() - checkedAt < config.githubValidationTtlSec * 1000;
+    if (
+      parsed.ok &&
+      fresh &&
+      allocation?.github_ok &&
+      allocation.github_owner &&
+      allocation.github_repo
+    ) {
+      return {
+        ok: true,
+        owner: allocation.github_owner,
+        repo: allocation.github_repo,
+        normalizedUrl: parsed.normalizedUrl,
+      };
+    }
+    return validateGithubRepo(app.github_url);
   }
 }
 
@@ -173,44 +337,183 @@ async function resetDailyWindowIfNeeded(client: pg.PoolClient, wallet: string): 
 async function dailyFundedForWallet(client: pg.PoolClient, wallet: string): Promise<bigint> {
   const rows = await client.query<{ total: string }>(
     `
-      SELECT COALESCE(sum(daily_funded_raw), 0)::text AS total
-      FROM seed_allocations
-      WHERE wallet = $1 AND daily_window = CURRENT_DATE
+      SELECT COALESCE(sum(amount_raw), 0)::text AS total
+      FROM seed_payouts
+      WHERE wallet = $1
+        AND status IN ('PENDING', 'SENT')
+        AND created_at >= date_trunc('day', now())
     `,
     [wallet],
   );
   return BigInt(rows.rows[0]?.total ?? "0");
 }
 
-async function recordFunding(
+async function refillActivityCount(
   client: pg.PoolClient,
+  wallet: string,
+  applicationId: string,
+  since: Date,
+): Promise<number> {
+  const rows = await client.query<{ count: string }>(
+    `
+      SELECT (
+        SELECT count(*)::int
+        FROM interactions
+        WHERE substrate_block_ts >= $3
+          AND (caller = $1 OR caller = $2 OR callee = $2)
+      ) + (
+        SELECT count(*)::int
+        FROM seed_spend_events
+        WHERE substrate_block_ts >= $4
+          AND wallet = $1
+          AND allowed = true
+      ) AS count
+    `,
+    [wallet, applicationId, since.getTime().toString(), since],
+  );
+  return Number(rows.rows[0]?.count ?? 0);
+}
+
+type PayoutSumScope =
+  | "global_daily"
+  | "app_lifetime"
+  | "wallet_lifetime"
+  | "github_lifetime"
+  | "repo_lifetime";
+
+async function payoutSum(
+  client: pg.PoolClient,
+  scope: PayoutSumScope,
+  values: { wallet?: string; applicationId?: string; githubOwner?: string; githubRepo?: string } = {},
+): Promise<bigint> {
+  const filters: string[] = ["status IN ('PENDING', 'SENT')"];
+  const args: string[] = [];
+  if (scope === "global_daily") {
+    filters.push("created_at >= date_trunc('day', now())");
+  }
+  if (scope === "app_lifetime") {
+    args.push(values.applicationId!);
+    filters.push(`application_id = $${args.length}`);
+  }
+  if (scope === "wallet_lifetime") {
+    args.push(values.wallet!);
+    filters.push(`wallet = $${args.length}`);
+  }
+  if (scope === "github_lifetime") {
+    args.push(values.githubOwner!.toLowerCase());
+    filters.push(`github_owner = $${args.length}`);
+  }
+  if (scope === "repo_lifetime") {
+    args.push(values.githubOwner!.toLowerCase(), values.githubRepo!.toLowerCase());
+    filters.push(`github_owner = $${args.length - 1} AND github_repo = $${args.length}`);
+  }
+
+  const rows = await client.query<{ total: string }>(
+    `SELECT COALESCE(sum(amount_raw), 0)::text AS total FROM seed_payouts WHERE ${filters.join(" AND ")}`,
+    args,
+  );
+  return BigInt(rows.rows[0]?.total ?? "0");
+}
+
+interface PayoutRow {
+  status: "PENDING" | "SENT" | "FAILED";
+  amount_raw: string;
+  tx_hash: string | null;
+}
+
+async function getPayout(client: pg.PoolClient, idempotencyKey: string): Promise<PayoutRow | null> {
+  const rows = await client.query<PayoutRow>(
+    `SELECT status, amount_raw::text, tx_hash FROM seed_payouts WHERE idempotency_key = $1 FOR UPDATE`,
+    [idempotencyKey],
+  );
+  return rows.rows[0] ?? null;
+}
+
+async function createPendingPayout(
+  client: pg.PoolClient,
+  payout: {
+    idempotencyKey: string;
+    wallet: string;
+    applicationId: string;
+    githubOwner: string;
+    githubRepo: string;
+    amount: bigint;
+    reason: string;
+  },
+): Promise<void> {
+  await client.query(
+    `
+      INSERT INTO seed_payouts (
+        idempotency_key, status, wallet, application_id, github_owner, github_repo, amount_raw, reason
+      )
+      VALUES ($1, 'PENDING', $2, $3, lower($4), lower($5), $6, $7)
+    `,
+    [
+      payout.idempotencyKey,
+      payout.wallet,
+      payout.applicationId,
+      payout.githubOwner,
+      payout.githubRepo,
+      payout.amount.toString(),
+      payout.reason,
+    ],
+  );
+}
+
+async function markPayoutSent(
+  idempotencyKey: string,
   wallet: string,
   applicationId: string,
   amountRaw: bigint,
   txHash: string,
   reason: string,
 ): Promise<void> {
-  await client.query(
-    `
-      INSERT INTO seed_funding_events (wallet, application_id, amount_raw, tx_hash, reason)
-      VALUES ($1, $2, $3, $4, $5)
-    `,
-    [wallet, applicationId, amountRaw.toString(), txHash, reason],
-  );
-  await client.query(
-    `
-      UPDATE seed_allocations
-      SET total_funded_raw = total_funded_raw + $3::numeric,
-          daily_funded_raw = daily_funded_raw + $3::numeric,
-          last_funded_at = now(),
-          last_reason = $4,
-          updated_at = now()
-      WHERE wallet = $1 AND application_id = $2
-    `,
-    [wallet, applicationId, amountRaw.toString(), reason],
-  );
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const updated = await client.query<{ idempotency_key: string }>(
+      `
+        UPDATE seed_payouts
+        SET status = 'SENT', tx_hash = $2, sent_at = now(), updated_at = now(), error = NULL
+        WHERE idempotency_key = $1 AND status = 'PENDING'
+        RETURNING idempotency_key
+      `,
+      [idempotencyKey, txHash],
+    );
+    if (updated.rows.length === 0) {
+      await client.query("COMMIT");
+      return;
+    }
+
+    await client.query(
+      `
+        INSERT INTO seed_funding_events (wallet, application_id, amount_raw, tx_hash, reason)
+        VALUES ($1, $2, $3, $4, $5)
+      `,
+      [wallet, applicationId, amountRaw.toString(), txHash, reason],
+    );
+    await client.query(
+      `
+        UPDATE seed_allocations
+        SET total_funded_raw = total_funded_raw + $3::numeric,
+            daily_funded_raw = daily_funded_raw + $3::numeric,
+            last_funded_at = now(),
+            last_reason = $4,
+            updated_at = now()
+        WHERE wallet = $1 AND application_id = $2
+      `,
+      [wallet, applicationId, amountRaw.toString(), reason],
+    );
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 
-function minBigInt(a: bigint, b: bigint): bigint {
-  return a < b ? a : b;
+function makePayoutKey(mode: "initial" | "refill", wallet: string, applicationId: string): string {
+  if (mode === "initial") return `initial:${wallet}:${applicationId}`;
+  return `refill:${wallet}:${applicationId}:${new Date().toISOString().slice(0, 10)}`;
 }

--- a/services/seed-backend/src/seed-service.ts
+++ b/services/seed-backend/src/seed-service.ts
@@ -20,6 +20,7 @@ import { ChainClient } from "./chain.js";
 import { requireAddress } from "./address.js";
 import { log } from "./logger.js";
 import { planPayout, type PayoutPolicy } from "./decision.js";
+import { payoutAttemptKey, payoutBaseKey, payoutBaseKeyLike } from "./payout-key.js";
 
 const INITIAL_TARGET = varaToPlanck(config.initialTargetVara);
 const REFILL_TARGET = varaToPlanck(config.refillTargetVara);
@@ -129,7 +130,7 @@ export class SeedService {
         applicationId,
         wallet: "",
         amountRaw: "0",
-        reason: `application is not found or not in eligible statuses: ${config.eligibleStatuses.join(", ")}`,
+        reason: "application is not registered",
       };
     }
     return this.fundApplication(app, mode);
@@ -228,19 +229,20 @@ export class SeedService {
         }
       }
 
-      const idempotencyKey = makePayoutKey(mode, wallet, applicationId);
-      const existing = await getPayout(client, idempotencyKey);
-      if (existing) {
+      const baseKey = payoutBaseKey(mode, wallet, applicationId);
+      const blockingPayout = await getBlockingPayout(client, baseKey);
+      if (blockingPayout) {
         await client.query("COMMIT");
         return {
-          status: existing.status === "SENT" ? "funded" : existing.status === "PENDING" ? "pending" : "skipped",
+          status: blockingPayout.status === "SENT" ? "funded" : "pending",
           applicationId,
           wallet,
-          amountRaw: existing.amount_raw,
-          reason: `payout is already ${existing.status.toLowerCase()}`,
-          txHash: existing.tx_hash ?? undefined,
+          amountRaw: blockingPayout.amount_raw,
+          reason: `payout is already ${blockingPayout.status.toLowerCase()}`,
+          txHash: blockingPayout.tx_hash ?? undefined,
         };
       }
+      const idempotencyKey = payoutAttemptKey(baseKey, await payoutAttemptCount(client, baseKey));
 
       await createPendingPayout(client, {
         idempotencyKey,
@@ -421,12 +423,32 @@ interface PayoutRow {
   tx_hash: string | null;
 }
 
-async function getPayout(client: pg.PoolClient, idempotencyKey: string): Promise<PayoutRow | null> {
+async function getBlockingPayout(client: pg.PoolClient, baseKey: string): Promise<PayoutRow | null> {
   const rows = await client.query<PayoutRow>(
-    `SELECT status, amount_raw::text, tx_hash FROM seed_payouts WHERE idempotency_key = $1 FOR UPDATE`,
-    [idempotencyKey],
+    `
+      SELECT status, amount_raw::text, tx_hash
+      FROM seed_payouts
+      WHERE (idempotency_key = $1 OR idempotency_key LIKE $2)
+        AND status IN ('PENDING', 'SENT')
+      ORDER BY created_at DESC
+      LIMIT 1
+      FOR UPDATE
+    `,
+    [baseKey, payoutBaseKeyLike(baseKey)],
   );
   return rows.rows[0] ?? null;
+}
+
+async function payoutAttemptCount(client: pg.PoolClient, baseKey: string): Promise<number> {
+  const rows = await client.query<{ count: string }>(
+    `
+      SELECT count(*)::text AS count
+      FROM seed_payouts
+      WHERE idempotency_key = $1 OR idempotency_key LIKE $2
+    `,
+    [baseKey, payoutBaseKeyLike(baseKey)],
+  );
+  return Number(rows.rows[0]?.count ?? 0);
 }
 
 async function createPendingPayout(
@@ -511,9 +533,4 @@ async function markPayoutSent(
   } finally {
     client.release();
   }
-}
-
-function makePayoutKey(mode: "initial" | "refill", wallet: string, applicationId: string): string {
-  if (mode === "initial") return `initial:${wallet}:${applicationId}`;
-  return `refill:${wallet}:${applicationId}:${new Date().toISOString().slice(0, 10)}`;
 }

--- a/services/seed-backend/src/seed-service.ts
+++ b/services/seed-backend/src/seed-service.ts
@@ -1,0 +1,216 @@
+import type pg from "pg";
+import { config, varaToPlanck } from "./config.js";
+import {
+  pool,
+  type ApplicationRow,
+  type FundingDecision,
+  getAllocationForUpdate,
+  getEligibleApplication,
+  listAllocations,
+  listEligibleApplications,
+  recordAudit,
+  upsertAllocation,
+} from "./db.js";
+import { validateGithubRepo } from "./github.js";
+import { ChainClient } from "./chain.js";
+import { requireAddress } from "./address.js";
+import { log } from "./logger.js";
+
+const INITIAL_TARGET = varaToPlanck(config.initialTargetVara);
+const REFILL_TARGET = varaToPlanck(config.refillTargetVara);
+const DAILY_CAP = varaToPlanck(config.maxDailyRefillVara);
+
+export class SeedService {
+  constructor(private readonly chain: ChainClient) {}
+
+  async claim(applicationId: string): Promise<FundingDecision> {
+    return this.fund(applicationId, "initial");
+  }
+
+  async refill(applicationId: string): Promise<FundingDecision> {
+    return this.fund(applicationId, "refill");
+  }
+
+  async scan(limit = 100): Promise<FundingDecision[]> {
+    const apps = await listEligibleApplications(limit);
+    const results: FundingDecision[] = [];
+    for (const app of apps) {
+      try {
+        const allocation = (await listAllocations(app.owner)).find(
+          (row) => row.application_id === app.id.toLowerCase(),
+        );
+        if (allocation && BigInt(allocation.total_funded_raw) > 0n) continue;
+        results.push(await this.fundApplication(app, "initial"));
+      } catch (error) {
+        log.warn("seed scan failed for app", { app: app.id, error: String(error) });
+      }
+    }
+    return results;
+  }
+
+  private async fund(applicationId: string, mode: "initial" | "refill"): Promise<FundingDecision> {
+    const app = await getEligibleApplication(applicationId);
+    if (!app) {
+      return {
+        status: "skipped",
+        applicationId,
+        wallet: "",
+        amountRaw: "0",
+        reason: `application is not found or not in eligible statuses: ${config.eligibleStatuses.join(", ")}`,
+      };
+    }
+    return this.fundApplication(app, mode);
+  }
+
+  private async fundApplication(app: ApplicationRow, mode: "initial" | "refill"): Promise<FundingDecision> {
+    const wallet = requireAddress(app.owner, "application owner");
+    const applicationId = requireAddress(app.id, "application id");
+
+    const github = await validateGithubRepo(app.github_url);
+    if (!github.ok) {
+      await upsertAllocation(app, false);
+      await recordAudit("warn", "github validation failed", { reason: github.reason }, wallet, applicationId);
+      return {
+        status: "skipped",
+        applicationId,
+        wallet,
+        amountRaw: "0",
+        reason: github.reason ?? "github validation failed",
+      };
+    }
+
+    await upsertAllocation(app, true);
+
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [wallet]);
+      const allocation = await getAllocationForUpdate(client, wallet, applicationId);
+      if (!allocation) throw new Error("allocation row disappeared after upsert");
+
+      if (allocation.state === "blacklisted" || allocation.state === "paused") {
+        await client.query("COMMIT");
+        return {
+          status: allocation.state,
+          applicationId,
+          wallet,
+          amountRaw: "0",
+          reason: allocation.last_reason ?? `allocation is ${allocation.state}`,
+        };
+      }
+
+      const now = Date.now();
+      if (mode === "refill" && allocation.last_funded_at) {
+        const next = allocation.last_funded_at.getTime() + config.minRefillIntervalSec * 1000;
+        if (now < next) {
+          await client.query("COMMIT");
+          return {
+            status: "skipped",
+            applicationId,
+            wallet,
+            amountRaw: "0",
+            reason: `refill interval has not elapsed; next eligible at ${new Date(next).toISOString()}`,
+          };
+        }
+      }
+
+      await resetDailyWindowIfNeeded(client, wallet);
+      const fresh = await getAllocationForUpdate(client, wallet, applicationId);
+      if (!fresh) throw new Error("allocation row disappeared after daily reset");
+
+      const currentBalance = await this.chain.balanceOf(wallet);
+      const totalFunded = BigInt(fresh.total_funded_raw);
+      const dailyFunded = await dailyFundedForWallet(client, wallet);
+      const target = totalFunded === 0n || mode === "initial" ? INITIAL_TARGET : REFILL_TARGET;
+      const needed = target > currentBalance ? target - currentBalance : 0n;
+      const dailyLeft = DAILY_CAP > dailyFunded ? DAILY_CAP - dailyFunded : 0n;
+      const amount = minBigInt(needed, dailyLeft);
+
+      if (amount <= 0n) {
+        await client.query("COMMIT");
+        return {
+          status: "skipped",
+          applicationId,
+          wallet,
+          amountRaw: "0",
+          reason: needed <= 0n ? "wallet balance is already at target" : "daily funding cap reached",
+        };
+      }
+
+      const txHash = await this.chain.transfer(wallet, amount);
+      await recordFunding(client, wallet, applicationId, amount, txHash, mode);
+      await client.query("COMMIT");
+
+      await recordAudit("info", "seed funds transferred", { amountRaw: amount.toString(), txHash, mode }, wallet, applicationId);
+      return {
+        status: "funded",
+        applicationId,
+        wallet,
+        amountRaw: amount.toString(),
+        reason: mode,
+        txHash,
+      };
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+async function resetDailyWindowIfNeeded(client: pg.PoolClient, wallet: string): Promise<void> {
+  await client.query(
+    `
+      UPDATE seed_allocations
+      SET daily_funded_raw = 0, daily_window = CURRENT_DATE, updated_at = now()
+      WHERE wallet = $1 AND daily_window <> CURRENT_DATE
+    `,
+    [wallet],
+  );
+}
+
+async function dailyFundedForWallet(client: pg.PoolClient, wallet: string): Promise<bigint> {
+  const rows = await client.query<{ total: string }>(
+    `
+      SELECT COALESCE(sum(daily_funded_raw), 0)::text AS total
+      FROM seed_allocations
+      WHERE wallet = $1 AND daily_window = CURRENT_DATE
+    `,
+    [wallet],
+  );
+  return BigInt(rows.rows[0]?.total ?? "0");
+}
+
+async function recordFunding(
+  client: pg.PoolClient,
+  wallet: string,
+  applicationId: string,
+  amountRaw: bigint,
+  txHash: string,
+  reason: string,
+): Promise<void> {
+  await client.query(
+    `
+      INSERT INTO seed_funding_events (wallet, application_id, amount_raw, tx_hash, reason)
+      VALUES ($1, $2, $3, $4, $5)
+    `,
+    [wallet, applicationId, amountRaw.toString(), txHash, reason],
+  );
+  await client.query(
+    `
+      UPDATE seed_allocations
+      SET total_funded_raw = total_funded_raw + $3::numeric,
+          daily_funded_raw = daily_funded_raw + $3::numeric,
+          last_funded_at = now(),
+          last_reason = $4,
+          updated_at = now()
+      WHERE wallet = $1 AND application_id = $2
+    `,
+    [wallet, applicationId, amountRaw.toString(), reason],
+  );
+}
+
+function minBigInt(a: bigint, b: bigint): bigint {
+  return a < b ? a : b;
+}

--- a/services/seed-backend/tsconfig.json
+++ b/services/seed-backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a new `services/seed-backend` service for server-managed VARA Seed Allocation.

Unlike the voucher backend, this service sends real liquid VARA to funded application wallets. The goal is to provide a small operational balance for hackathon agents without turning seed funding into an unrestricted faucet.

The service uses a backend-controlled top-up model:

1. The service reads registered hackathon applications from the indexer `applications` table.
2. Any registered application can request seed funding; application review statuses are not used as a funding gate.
3. `applications.owner` is treated as the funded agent wallet.
4. Before funding, the service validates the app GitHub repository:
   - valid `github.com` repository URL;
   - public repository exists;
   - repository is not empty;
   - recent activity exists;
   - README exists;
   - repository contains actual code files.
5. If checks pass, the backend creates a `PENDING` payout and tops up the agent wallet toward the configured target balance.
6. The initial target is controlled by `INITIAL_TARGET_VARA`.
7. Later refills are controlled by `REFILL_TARGET_VARA`, refill cooldown, activity requirements, and daily/lifetime caps.
8. The service enforces caps per app, wallet, GitHub owner, GitHub repo, and globally per day.
9. The monitor watches finalized blocks for outgoing `balances.Transfer` events and Gear `sendMessage` calls with attached `value` from funded wallets.
10. Spending to registered hackathon application program IDs is allowed.
11. Spending to unrelated wallets can pause or blacklist the wallet/application from future refills.

This keeps the participant flow simple: no treasury contract, no extra participant-side integration, and no status-dependent funding setup.

## Backend Flow

### Initial funding

1. A participant registers and deploys an application.
2. The indexer writes the application into the `applications` table.
3. The seed backend receives a `POST /seed/claim` request or finds the app during `POST /seed/scan`.
4. The backend loads the application by `applicationId`.
5. The backend treats `applications.owner` as the agent wallet.
6. The backend validates the app GitHub repository.
7. The backend checks allocation state and funding limits:
   - allocation is not paused or blacklisted;
   - wallet balance is below the target;
   - per-app lifetime cap is not exceeded;
   - per-wallet lifetime cap is not exceeded;
   - per-GitHub-owner cap is not exceeded;
   - per-repo cap is not exceeded;
   - wallet daily cap is not exceeded;
   - global daily payout limit is not exceeded.
8. The backend creates a `PENDING` payout with an idempotency key.
9. The backend sends VARA from the configured seed account.
10. After the transfer is finalized, the payout is marked as `SENT`, and allocation/funding ledgers are updated.

### Refill

1. A refill request is received via `POST /seed/refill`.
2. The backend checks the same allocation and cap rules.
3. The backend also checks:
   - minimum refill interval has elapsed;
   - required activity exists since the last funding event.
4. If the wallet balance is below `REFILL_TARGET_VARA`, the backend tops it up toward the target.
5. If the wallet was paused or blacklisted by the monitor, no refill is sent.

### Spend monitoring

1. The monitor scans finalized blocks from `MONITOR_START_BLOCK`.
2. By default, a fresh deployment starts from the latest finalized block.
3. The monitor tracks funded wallets and detects:
   - outgoing `balances.Transfer` events;
   - Gear `sendMessage` calls with non-zero attached `value`.
4. If the recipient is a registered application program ID, the spend is allowed.
5. If the recipient is not a registered application, the spend is recorded as suspicious.
6. Suspicious spend above `SUSPICIOUS_PAUSE_THRESHOLD_VARA` pauses future refills.
7. Repeated suspicious spend can blacklist the wallet/application according to `BLACKLIST_THRESHOLD`.

## What Changed

- Added standalone `services/seed-backend`.
- Reads registered applications from the indexer DB `applications` table.
- Removed funding dependency on application review statuses.
- Uses `applications.owner` as the funded agent wallet.
- Validates GitHub repositories before funding:
  - valid `github.com` URL;
  - public repo exists;
  - repo is not empty;
  - recent commits/activity;
  - README exists;
  - contains code files.
- Uses a top-up model instead of one-time unrestricted grants.
- Sends initial funding toward `INITIAL_TARGET_VARA`.
- Supports refills toward `REFILL_TARGET_VARA`.
- Enforces:
  - per-wallet daily cap via `MAX_DAILY_REFILL_VARA`;
  - global daily cap via `GLOBAL_DAILY_PAYOUT_LIMIT_VARA`;
  - per-app lifetime cap via `LIFETIME_CAP_APP_VARA`;
  - per-wallet lifetime cap via `LIFETIME_CAP_WALLET_VARA`;
  - per-GitHub-owner lifetime cap via `LIFETIME_CAP_GITHUB_VARA`;
  - per-repo lifetime cap via `LIFETIME_CAP_REPO_VARA`;
  - refill cooldown via `MIN_REFILL_INTERVAL_SEC`;
  - refill activity requirement via `MIN_REFILL_ACTIVITY_EVENTS`.
- Adds `PENDING -> SENT` payout accounting to avoid unsafe repeated payouts.
- Supports payout retry attempts after cancelled payouts.
- Stores seed allocation ledger, payout ledger, funding events, spend events, monitor cursor, and audit events in Postgres.
- Monitors finalized blocks for:
  - `balances.Transfer`;
  - Gear `sendMessage` calls with attached `value`.
- Allows spending to registered application program IDs.
- Pauses or blacklists wallets on suspicious outgoing spend.
- Requires `SEED_API_KEY` in production.
- Starts monitoring from the latest finalized block by default to avoid accidental full-chain scans.
- Added `.env.example`, `README.md`, `Dockerfile`, migrations, and tests.
- Updated `.gitignore` to ignore seed backend build output.