### PR TITLE
Idempotent Issue: dedupe on (caller, subject)

### DIFF
--- a/programs/examples/priced-attestation/README.md
+++ b/programs/examples/priced-attestation/README.md
@@ -12,19 +12,21 @@ A buildable, tested receiver-side reference for charging fees in a Sails program
 
 - **Value guard** at the top of `Issue` — reject `msg::value() < required_fee()` with a typed `Err(InsufficientPayment)` and refund the full inbound value via `CommandReply::with_value`.
 - **Anti-cheat self-loop reject** — reject `msg::source() == exec::program_id()` with `Err(SelfLoop)` and full refund.
+- **Idempotency dedupe on `(caller, subject)`** — a retry on the same key returns the existing `Receipt` and refunds the full new payment via `DuplicateRefunded`. Callers can blind-retry on RPC timeouts without double-paying. Distinct event from `ReceiptIssued` so off-chain indexers can count both.
 - **Overflow-checked counter bumps** — `next_seq` and `collected_fees` use `checked_add`; an overflow surfaces as `Err(ArithmeticOverflow)` with full refund instead of silent saturation.
 - **Combined refund block** — success path refunds excess via `CommandReply::with_value(excess)` atomically with the `Ok(Receipt)` reply. No separate `msg::send_bytes` (which would not fire on Err returns per Gear/Sails reply semantics).
-- **Plain owner gate** — `owner: ActorId` set in the constructor. Reserved for `SetFee` / `WithdrawFees` in the next iteration. For production multi-admin / time-locked control, swap in `awesome-sails::access-control` (see `pricing.md`'s "Upgrading to RBAC" section).
+- **Owner-gated SetFee / WithdrawFees** — plain `msg::source() == self.owner` gate via private `ensure_owner()` helper. For production multi-admin / time-locked control, swap in `awesome-sails::access-control` (see `pricing.md`'s "Upgrading to RBAC" section).
 
 ## Refund matrix
 
-| Branch                            | Reply                                | Refund delivered    |
-| --------------------------------- | ------------------------------------ | ------------------- |
-| Underpayment                      | `Err(InsufficientPayment)`           | full `msg::value()` |
-| Self-loop (program calls itself)  | `Err(SelfLoop)`                      | full `msg::value()` |
-| Counter overflow                  | `Err(ArithmeticOverflow)`            | full `msg::value()` |
-| Success + exact payment           | `Ok(Receipt)`, `ReceiptIssued` event | none                |
-| Success + overpayment             | `Ok(Receipt)`, `ReceiptIssued` event | excess only         |
+| Branch                            | Reply                                  | Refund delivered    |
+| --------------------------------- | -------------------------------------- | ------------------- |
+| Self-loop (program calls itself)  | `Err(SelfLoop)`                        | full `msg::value()` |
+| Idempotent retry                  | `Ok(existing Receipt)`, `DuplicateRefunded` event | full `msg::value()` |
+| Underpayment                      | `Err(InsufficientPayment)`             | full `msg::value()` |
+| Counter overflow                  | `Err(ArithmeticOverflow)`              | full `msg::value()` |
+| First-time + exact payment        | `Ok(Receipt)`, `ReceiptIssued` event   | none                |
+| First-time + overpayment          | `Ok(Receipt)`, `ReceiptIssued` event   | excess only         |
 
 Refunds are bundled into the reply via `CommandReply<Result<Receipt, Error>>::with_value(amount)`. This is the canonical Sails-rs 0.10 pattern. A separate `msg::send_bytes` queued from a handler that returns `Err` does **not** fire — outbound side effects only flush on successful execution per `gear-messaging-and-replies.md`.
 
@@ -42,24 +44,31 @@ Produces `target/wasm32-gear/release/priced_attestation.opt.wasm` and `priced_at
 cargo test --release
 ```
 
-Seven payment-logic scenarios pass green:
+Twelve payment-logic scenarios pass green:
 
+**Refund branches (`Issue`):**
 - `issue_with_exact_fee_succeeds_and_charges_caller` — `Ok(Receipt)`, fee retained, balance delta == fee.
 - `issue_with_overpayment_keeps_fee_and_refunds_excess` — `Ok(Receipt)`, balance delta < 2x fee (excess refunded).
-- `issue_with_underpayment_returns_typed_err_and_refunds_full_value` — `Err(InsufficientPayment)`, balance delta < attached value (full refund).
+- `issue_with_underpayment_returns_typed_err_and_refunds_full_value` — `Err(InsufficientPayment)`, full refund.
+
+**Idempotency dedupe:**
+- `issue_idempotent_retry_returns_existing_receipt_and_refunds_payment` — same `(caller, subject)` twice; second returns the original `Receipt` (same seq) and refunds full new payment. `collected_fees` unchanged.
+- `issue_distinct_callers_same_subject_get_distinct_receipts` — caller is part of the dedupe key.
+- `issue_same_caller_distinct_subjects_get_distinct_receipts` — subject is part of the dedupe key.
+- `issue_idempotent_retry_with_overpayment_refunds_full_payment` — retry path refunds the entire `msg::value()`, not just the excess (no fee charge on retry).
+- `issue_with_zero_fee_mode_accepts_zero_payment` — `SetFee(0)` then zero-value `Issue` succeeds.
+
+**Owner-gated mutations:**
 - `set_fee_from_non_owner_returns_unauthorized` — `Err(Unauthorized)`, fee unchanged.
 - `set_fee_from_owner_succeeds_and_subsequent_issue_uses_new_fee` — `Ok(())`, `FeeChanged` event, post-set old fee underpays, new fee succeeds.
 - `withdraw_fees_owner_drains_collected_and_credits_owner` — `Ok(amount)`, `collected_fees == 0` after, owner balance increased.
 - `withdraw_fees_exceeding_collected_returns_typed_err` — `Err(WithdrawExceedsCollected)`, no state change.
 
-The self-loop branch is exercised in production but **not** in this gtest harness — `gtest::System` panics with *"Sending messages allowed only from users id"* when `with_actor_id(program_id)` is set. The two-program harness in the Phase 2 consumer example covers that path.
+The self-loop branch is exercised in production but **not** in this gtest harness — `gtest::System` panics with *"Sending messages allowed only from users id"* when `with_actor_id(program_id)` is set. The two-program harness in the Phase 2 consumer example covers that path. `Err(ArithmeticOverflow)` is similarly in source but not gtest-tested (would require priming counters near `u64::MAX` / `u128::MAX`, possible via direct state injection but not via the public IDL surface).
 
 ## Scope of this iteration
 
-Receiver-side fee mechanics are complete: `Issue` (with all refund branches), `SetFee` (owner-gated fee adjustment), `WithdrawFees` (owner-gated draw against `collected_fees`). Reserved for the next iteration:
-
-- Idempotency: dedupe on `(caller, subject)` keyed `BTreeMap<(ActorId, [u8; 32]), Receipt>` so retries return the existing receipt and refund the new payment.
-- 9 additional gtest scenarios (idempotency cross-caller, idempotency same-subject distinct-callers, zero-fee mode, very-large-fee overflow boundaries) per the plan.
+Receiver-side fee mechanics complete: `Issue` (with all refund branches and idempotency dedupe), `SetFee` (owner-gated fee adjustment), `WithdrawFees` (owner-gated draw against `collected_fees`). The Phase 2 consumer example (`programs/examples/priced-attestation-consumer/`) is the natural next step — it will cover the program-side caller pattern and exercise the self-loop branch via a real two-program harness.
 
 ## License
 

--- a/programs/examples/priced-attestation/app/src/lib.rs
+++ b/programs/examples/priced-attestation/app/src/lib.rs
@@ -4,15 +4,18 @@
 //! Demonstrates the `pricing.md` combined refund block: value guard at the
 //! top, anti-cheat self-loop reject, refund-on-error, overpayment refund.
 //!
-//! This first iteration is intentionally minimal — happy path + the two
-//! refund branches. Idempotency (dedupe on `(caller, subject)`), `SetFee`,
-//! and `WithdrawFees` land in the next iteration.
+//! Idempotency: `Issue` deduplicates on `(caller, subject)`. A retry on the
+//! same key returns the existing `Receipt` and refunds the full new payment
+//! (no fee charge), so callers can blind-retry on RPC timeouts without
+//! double-paying. `DuplicateRefunded` event distinguishes retries from
+//! first-time issues so off-chain consumers can count both.
 
 #![no_std]
 
 extern crate alloc;
 
 use sails_rs::cell::RefCell;
+use sails_rs::collections::BTreeMap;
 use sails_rs::gstd::{CommandReply, exec, msg};
 use sails_rs::prelude::*;
 
@@ -33,7 +36,10 @@ pub enum AttestationKind {
     Custom,
 }
 
-/// Sequence-numbered attestation. Stable across retries once we add dedupe.
+/// Sequence-numbered attestation. Stable across retries — `Issue` dedupes on
+/// `(caller, subject)`, so retrying the same call returns the original
+/// `Receipt` (same `seq`, `issued_at`, `fee_paid`) rather than minting a new
+/// one.
 #[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
 #[codec(crate = sails_rs::scale_codec)]
 #[scale_info(crate = sails_rs::scale_info)]
@@ -80,12 +86,21 @@ pub struct AttestState {
     /// Monotonic receipt counter. First receipt has `seq = 1` so that
     /// `receipt_count()` returns the actual issued count. (`seq = 0` is
     /// reserved for "no receipts yet".)
+    ///
+    /// Retained as an explicit `u64` field rather than derived from
+    /// `receipts.len()` because Vara's wasm32 target makes `usize` 32-bit;
+    /// we want the seq guarantee to hold beyond u32::MAX entries.
     pub next_seq: u64,
     /// Accounting only — reflects fees the program accepted via `Issue`.
     /// Not authoritative chain balance: value can arrive via other paths
     /// (forced transfers, etc.) and `WithdrawFees` only draws against this
     /// counter, not against arbitrary balance.
     pub collected_fees: u128,
+    /// Idempotency dedupe: `(caller, subject) -> Receipt`. A retry on the
+    /// same key returns the existing `Receipt` and refunds the full new
+    /// payment via `DuplicateRefunded`, so callers can blind-retry on RPC
+    /// timeouts without double-paying.
+    pub receipts: BTreeMap<(ActorId, [u8; 32]), Receipt>,
 }
 
 // ---------------------------------------------------------------------------
@@ -97,12 +112,22 @@ pub struct AttestState {
 #[codec(crate = sails_rs::scale_codec)]
 #[scale_info(crate = sails_rs::scale_info)]
 pub enum AttestEvent {
+    /// First-time issuance for a `(caller, subject)` pair. Off-chain
+    /// indexers count `integrationsIn` and revenue from this event.
     ReceiptIssued {
         caller: ActorId,
         subject: [u8; 32],
         kind: AttestationKind,
         seq: u64,
         fee_paid: u128,
+    },
+    /// Idempotent retry on a `(caller, subject)` already issued. The
+    /// existing `Receipt` is reused and the full new payment is refunded.
+    /// Distinct event so indexers can separate retries from new issues.
+    DuplicateRefunded {
+        caller: ActorId,
+        subject: [u8; 32],
+        refunded: u128,
     },
     FeeChanged {
         old: u128,
@@ -164,18 +189,27 @@ impl<'a> AttestService<'a> {
     /// Issue an attestation. Caller must attach `msg::value() >= required_fee()`.
     ///
     /// Refund matrix (per `agent-starter/references/pricing.md`):
-    /// - Underpayment      → `Err(InsufficientPayment)`,  full value refunded.
-    /// - Self-loop         → `Err(SelfLoop)`,             full value refunded.
-    /// - ArithmeticOverflow → `Err(ArithmeticOverflow)`,  full value refunded.
-    /// - Success + overpay → `Ok(Receipt)`,               excess refunded.
-    /// - Success + exact   → `Ok(Receipt)`,               no refund.
+    /// - Self-loop                 → `Err(SelfLoop)`,             full value refunded.
+    /// - Idempotent retry          → `Ok(existing Receipt)`,      full value refunded (no fee charge).
+    /// - Underpayment              → `Err(InsufficientPayment)`,  full value refunded.
+    /// - ArithmeticOverflow        → `Err(ArithmeticOverflow)`,   full value refunded.
+    /// - First-time + overpayment  → `Ok(Receipt)`,               excess refunded.
+    /// - First-time + exact        → `Ok(Receipt)`,               no refund.
     ///
     /// Refunds are delivered via `CommandReply::with_value(...)` — the reply
     /// itself carries the refund. Per Gear/Sails semantics, a separate
     /// `msg::send_bytes` queued from a handler that returns `Err` does NOT
     /// fire (`gear-messaging-and-replies.md`: "outbound send and reply effects
     /// appear only after successful execution"). Bundling the refund into the
-    /// reply is the canonical Sails pattern and works on both Err and Ok paths.
+    /// reply is the canonical Sails pattern and works on Err, Ok, and the
+    /// idempotent-retry-Ok path uniformly.
+    ///
+    /// The retry-Ok path returns the original `Receipt` (same `seq`,
+    /// `issued_at`, `fee_paid`) and emits `DuplicateRefunded` instead of
+    /// `ReceiptIssued`. Callers can blind-retry on RPC timeouts without
+    /// double-paying — the retry is observably distinct from the original
+    /// (different event), economically equivalent (full refund), and
+    /// idempotent at the receipt level (same `seq` returned).
     #[export]
     pub fn issue(
         &mut self,
@@ -186,63 +220,89 @@ impl<'a> AttestService<'a> {
         let source = msg::source();
 
         // --- Anti-cheat: reject self-loop callers (pricing.md anti-cheat block).
-        // Cheap path; no state read needed.
+        // Anti-cheat trumps idempotency: even if `(program_id, subject)` is in
+        // the dedupe map, a self-loop call still rejects.
         if source == exec::program_id() {
             return CommandReply::new(Err(Error::SelfLoop)).with_value(value);
         }
 
-        // Single state borrow covers fee read + value guard + overflow-checked
-        // counter bumps. Early returns inside the block drop the borrow
-        // before constructing the refund. Refund full inbound value on every
-        // typed-Err branch so the caller is made whole.
-        let (seq, fee) = {
+        // Two paths inside one borrow scope: idempotent retry vs first-time
+        // issue. Early returns inside the block drop the borrow before
+        // constructing the refund.
+        enum Path {
+            Retry(Receipt),
+            New(Receipt, u128),
+        }
+        let path = {
             let mut state = self.state.borrow_mut();
-            let fee = state.flat_fee;
-            if value < fee {
-                return CommandReply::new(Err(Error::InsufficientPayment))
-                    .with_value(value);
+
+            // --- Idempotent retry: key already issued. Reuse existing.
+            if let Some(existing) = state.receipts.get(&(source, subject)) {
+                Path::Retry(existing.clone())
+            } else {
+                // --- First-time issue: value guard + overflow-checked bumps.
+                let fee = state.flat_fee;
+                if value < fee {
+                    return CommandReply::new(Err(Error::InsufficientPayment))
+                        .with_value(value);
+                }
+                let next_seq = match state.next_seq.checked_add(1) {
+                    Some(n) => n,
+                    None => {
+                        return CommandReply::new(Err(Error::ArithmeticOverflow))
+                            .with_value(value);
+                    }
+                };
+                let new_collected = match state.collected_fees.checked_add(fee) {
+                    Some(c) => c,
+                    None => {
+                        return CommandReply::new(Err(Error::ArithmeticOverflow))
+                            .with_value(value);
+                    }
+                };
+                state.next_seq = next_seq;
+                state.collected_fees = new_collected;
+
+                let receipt = Receipt {
+                    seq: next_seq,
+                    caller: source,
+                    subject,
+                    kind,
+                    fee_paid: fee,
+                    issued_at: exec::block_timestamp(),
+                };
+                state.receipts.insert((source, subject), receipt.clone());
+                Path::New(receipt, fee)
             }
-            let next_seq = match state.next_seq.checked_add(1) {
-                Some(n) => n,
-                None => {
-                    return CommandReply::new(Err(Error::ArithmeticOverflow))
-                        .with_value(value);
-                }
-            };
-            let new_collected = match state.collected_fees.checked_add(fee) {
-                Some(c) => c,
-                None => {
-                    return CommandReply::new(Err(Error::ArithmeticOverflow))
-                        .with_value(value);
-                }
-            };
-            state.next_seq = next_seq;
-            state.collected_fees = new_collected;
-            (next_seq, fee)
-        };
-        let excess = value - fee;
-
-        let receipt = Receipt {
-            seq,
-            caller: source,
-            subject,
-            kind,
-            fee_paid: fee,
-            issued_at: exec::block_timestamp(),
         };
 
-        self.emit_event(AttestEvent::ReceiptIssued {
-            caller: source,
-            subject,
-            kind,
-            seq,
-            fee_paid: fee,
-        })
-        .expect("emit ReceiptIssued failed");
-
-        // --- Success path: refund excess via the reply's value. excess == 0
-        // is fine — with_value(0) is a no-op from the chain's perspective.
-        CommandReply::new(Ok(receipt)).with_value(excess)
+        // emit_event is a `&mut self` method on the macro-generated
+        // Exposure; it can't run inside the state borrow above, so the path
+        // enum threads the result out and we emit + reply here.
+        match path {
+            Path::Retry(receipt) => {
+                self.emit_event(AttestEvent::DuplicateRefunded {
+                    caller: source,
+                    subject,
+                    refunded: value,
+                })
+                .expect("emit DuplicateRefunded failed");
+                // Return the original receipt; refund the entire new payment.
+                CommandReply::new(Ok(receipt)).with_value(value)
+            }
+            Path::New(receipt, fee) => {
+                self.emit_event(AttestEvent::ReceiptIssued {
+                    caller: source,
+                    subject,
+                    kind,
+                    seq: receipt.seq,
+                    fee_paid: fee,
+                })
+                .expect("emit ReceiptIssued failed");
+                let excess = value - fee;
+                CommandReply::new(Ok(receipt)).with_value(excess)
+            }
+        }
     }
 
     /// Owner-gated. Adjust `flat_fee`. Emits `FeeChanged { old, new }` only
@@ -323,6 +383,7 @@ impl Program {
                 flat_fee,
                 next_seq: 0,
                 collected_fees: 0,
+                receipts: BTreeMap::new(),
             }),
         }
     }

--- a/programs/examples/priced-attestation/client/priced_attestation_client.idl
+++ b/programs/examples/priced-attestation/client/priced_attestation_client.idl
@@ -8,7 +8,10 @@ type AttestationKind = enum {
   Custom,
 };
 
-/// Sequence-numbered attestation. Stable across retries once we add dedupe.
+/// Sequence-numbered attestation. Stable across retries — `Issue` dedupes on
+/// `(caller, subject)`, so retrying the same call returns the original
+/// `Receipt` (same `seq`, `issued_at`, `fee_paid`) rather than minting a new
+/// one.
 type Receipt = struct {
   seq: u64,
   caller: actor_id,
@@ -49,18 +52,27 @@ service Attest {
   /// Issue an attestation. Caller must attach `msg::value() >= required_fee()`.
   /// 
   /// Refund matrix (per `agent-starter/references/pricing.md`):
-  /// - Underpayment      → `Err(InsufficientPayment)`,  full value refunded.
-  /// - Self-loop         → `Err(SelfLoop)`,             full value refunded.
-  /// - ArithmeticOverflow → `Err(ArithmeticOverflow)`,  full value refunded.
-  /// - Success + overpay → `Ok(Receipt)`,               excess refunded.
-  /// - Success + exact   → `Ok(Receipt)`,               no refund.
+  /// - Self-loop                 → `Err(SelfLoop)`,             full value refunded.
+  /// - Idempotent retry          → `Ok(existing Receipt)`,      full value refunded (no fee charge).
+  /// - Underpayment              → `Err(InsufficientPayment)`,  full value refunded.
+  /// - ArithmeticOverflow        → `Err(ArithmeticOverflow)`,   full value refunded.
+  /// - First-time + overpayment  → `Ok(Receipt)`,               excess refunded.
+  /// - First-time + exact        → `Ok(Receipt)`,               no refund.
   /// 
   /// Refunds are delivered via `CommandReply::with_value(...)` — the reply
   /// itself carries the refund. Per Gear/Sails semantics, a separate
   /// `msg::send_bytes` queued from a handler that returns `Err` does NOT
   /// fire (`gear-messaging-and-replies.md`: "outbound send and reply effects
   /// appear only after successful execution"). Bundling the refund into the
-  /// reply is the canonical Sails pattern and works on both Err and Ok paths.
+  /// reply is the canonical Sails pattern and works on Err, Ok, and the
+  /// idempotent-retry-Ok path uniformly.
+  /// 
+  /// The retry-Ok path returns the original `Receipt` (same `seq`,
+  /// `issued_at`, `fee_paid`) and emits `DuplicateRefunded` instead of
+  /// `ReceiptIssued`. Callers can blind-retry on RPC timeouts without
+  /// double-paying — the retry is observably distinct from the original
+  /// (different event), economically equivalent (full refund), and
+  /// idempotent at the receipt level (same `seq` returned).
   Issue : (subject: [u8, 32], kind: AttestationKind) -> result (Receipt, Error);
   /// Owner-gated. Adjust `flat_fee`. Emits `FeeChanged { old, new }` only
   /// when the value actually changes (no-op set is silent).
@@ -86,12 +98,22 @@ service Attest {
   query RequiredFee : () -> u128;
 
   events {
+    /// First-time issuance for a `(caller, subject)` pair. Off-chain
+    /// indexers count `integrationsIn` and revenue from this event.
     ReceiptIssued: struct {
       caller: actor_id,
       subject: [u8, 32],
       kind: AttestationKind,
       seq: u64,
       fee_paid: u128,
+    };
+    /// Idempotent retry on a `(caller, subject)` already issued. The
+    /// existing `Receipt` is reused and the full new payment is refunded.
+    /// Distinct event so indexers can separate retries from new issues.
+    DuplicateRefunded: struct {
+      caller: actor_id,
+      subject: [u8, 32],
+      refunded: u128,
     };
     FeeChanged: struct {
       old: u128,

--- a/programs/examples/priced-attestation/client/src/priced_attestation_client.rs
+++ b/programs/examples/priced-attestation/client/src/priced_attestation_client.rs
@@ -53,18 +53,27 @@ pub mod attest {
         /// Issue an attestation. Caller must attach `msg::value() >= required_fee()`.
         ///
         /// Refund matrix (per `agent-starter/references/pricing.md`):
-        /// - Underpayment      → `Err(InsufficientPayment)`,  full value refunded.
-        /// - Self-loop         → `Err(SelfLoop)`,             full value refunded.
-        /// - ArithmeticOverflow → `Err(ArithmeticOverflow)`,  full value refunded.
-        /// - Success + overpay → `Ok(Receipt)`,               excess refunded.
-        /// - Success + exact   → `Ok(Receipt)`,               no refund.
+        /// - Self-loop                 → `Err(SelfLoop)`,             full value refunded.
+        /// - Idempotent retry          → `Ok(existing Receipt)`,      full value refunded (no fee charge).
+        /// - Underpayment              → `Err(InsufficientPayment)`,  full value refunded.
+        /// - ArithmeticOverflow        → `Err(ArithmeticOverflow)`,   full value refunded.
+        /// - First-time + overpayment  → `Ok(Receipt)`,               excess refunded.
+        /// - First-time + exact        → `Ok(Receipt)`,               no refund.
         ///
         /// Refunds are delivered via `CommandReply::with_value(...)` — the reply
         /// itself carries the refund. Per Gear/Sails semantics, a separate
         /// `msg::send_bytes` queued from a handler that returns `Err` does NOT
         /// fire (`gear-messaging-and-replies.md`: "outbound send and reply effects
         /// appear only after successful execution"). Bundling the refund into the
-        /// reply is the canonical Sails pattern and works on both Err and Ok paths.
+        /// reply is the canonical Sails pattern and works on Err, Ok, and the
+        /// idempotent-retry-Ok path uniformly.
+        ///
+        /// The retry-Ok path returns the original `Receipt` (same `seq`,
+        /// `issued_at`, `fee_paid`) and emits `DuplicateRefunded` instead of
+        /// `ReceiptIssued`. Callers can blind-retry on RPC timeouts without
+        /// double-paying — the retry is observably distinct from the original
+        /// (different event), economically equivalent (full refund), and
+        /// idempotent at the receipt level (same `seq` returned).
         fn issue(
             &mut self,
             subject: [u8; 32],
@@ -148,12 +157,22 @@ pub mod attest {
         #[derive(PartialEq, Debug, Encode, Decode)]
         #[codec(crate = sails_rs::scale_codec)]
         pub enum AttestEvents {
+            /// First-time issuance for a `(caller, subject)` pair. Off-chain
+            /// indexers count `integrationsIn` and revenue from this event.
             ReceiptIssued {
                 caller: ActorId,
                 subject: [u8; 32],
                 kind: AttestationKind,
                 seq: u64,
                 fee_paid: u128,
+            },
+            /// Idempotent retry on a `(caller, subject)` already issued. The
+            /// existing `Receipt` is reused and the full new payment is refunded.
+            /// Distinct event so indexers can separate retries from new issues.
+            DuplicateRefunded {
+                caller: ActorId,
+                subject: [u8; 32],
+                refunded: u128,
             },
             FeeChanged {
                 old: u128,
@@ -166,7 +185,12 @@ pub mod attest {
             },
         }
         impl sails_rs::client::Event for AttestEvents {
-            const EVENT_NAMES: &'static [Route] = &["ReceiptIssued", "FeeChanged", "FeesWithdrawn"];
+            const EVENT_NAMES: &'static [Route] = &[
+                "ReceiptIssued",
+                "DuplicateRefunded",
+                "FeeChanged",
+                "FeesWithdrawn",
+            ];
         }
         impl sails_rs::client::ServiceWithEvents for AttestImpl {
             type Event = AttestEvents;
@@ -185,7 +209,10 @@ pub enum AttestationKind {
     /// Custom domain receipt — the caller's `subject` carries semantics.
     Custom,
 }
-/// Sequence-numbered attestation. Stable across retries once we add dedupe.
+/// Sequence-numbered attestation. Stable across retries — `Issue` dedupes on
+/// `(caller, subject)`, so retrying the same call returns the original
+/// `Receipt` (same `seq`, `issued_at`, `fee_paid`) rather than minting a new
+/// one.
 #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
 #[codec(crate = sails_rs::scale_codec)]
 #[scale_info(crate = sails_rs::scale_info)]

--- a/programs/examples/priced-attestation/tests/gtest.rs
+++ b/programs/examples/priced-attestation/tests/gtest.rs
@@ -1,14 +1,19 @@
-//! Phase 1 canary: happy path + the three refund branches.
+//! Payment-logic harness — every claim in the `Issue` doc-comment refund
+//! matrix plus the idempotency dedupe contract:
+//!   - Exact payment             → Ok(Receipt), fee retained, no refund queued.
+//!   - Overpayment               → Ok(Receipt), fee retained, excess refunded.
+//!   - Underpayment              → Err(InsufficientPayment), full refund.
+//!   - Self-loop                 → Err(SelfLoop), full refund. (Not gtest-tested;
+//!                                 see note below.)
+//!   - Idempotent retry          → Ok(existing Receipt), full refund, no new seq.
+//!   - Distinct callers / subjects → independent receipts (caller AND subject
+//!                                   are part of the dedupe key).
+//!   - Zero-fee mode             → Issue(0) succeeds when SetFee(0) was called.
+//!   - Owner-gated SetFee, WithdrawFees, including failure modes.
 //!
-//! Together these exercise every claim in the `Issue` doc-comment refund
-//! matrix:
-//!   - Exact payment    → Ok(Receipt), fee retained, no refund queued.
-//!   - Overpayment      → Ok(Receipt), fee retained, excess refunded.
-//!   - Underpayment     → Err(InsufficientPayment), full refund.
-//!   - Self-loop        → Err(SelfLoop), full refund.
-//!
-//! The full 16-scenario harness (idempotency, owner-gated SetFee/WithdrawFees,
-//! ArithmeticOverflow, etc.) lands in the next iteration.
+//! ArithmeticOverflow is in source but not gtest-tested (would require
+//! priming `next_seq` or `collected_fees` near u64/u128 max — possible via
+//! direct state injection but not via the public IDL surface).
 
 use priced_attestation_client::{
     AttestationKind, Error, PricedAttestationClient, PricedAttestationClientCtors,
@@ -286,4 +291,194 @@ async fn withdraw_fees_exceeding_collected_returns_typed_err() {
 
     assert_eq!(result, Err(Error::WithdrawExceedsCollected));
     assert_eq!(attest.collected_fees().query().unwrap(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency (dedupe on `(caller, subject)`)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn issue_idempotent_retry_returns_existing_receipt_and_refunds_payment() {
+    let (program, env) = deploy_program().await;
+    let mut attest = program.attest();
+    let subject = [0xAA; 32];
+
+    // First-time issue: charges fee, mints receipt seq=1.
+    let first = attest
+        .issue(subject, AttestationKind::Action)
+        .with_actor_id(CALLER.into())
+        .with_value(FLAT_FEE)
+        .await
+        .unwrap()
+        .expect("first Issue should succeed");
+    assert_eq!(first.seq, 1);
+    assert_eq!(first.fee_paid, FLAT_FEE);
+    assert_eq!(attest.receipt_count().query().unwrap(), 1);
+    assert_eq!(attest.collected_fees().query().unwrap(), FLAT_FEE);
+
+    let before = env.system().balance_of(CALLER);
+
+    // Retry on same (caller, subject): returns existing receipt + refunds new payment.
+    let retry = attest
+        .issue(subject, AttestationKind::Action)
+        .with_actor_id(CALLER.into())
+        .with_value(FLAT_FEE)
+        .await
+        .unwrap()
+        .expect("retry must surface the existing receipt as Ok");
+
+    // Same receipt as the first call — same seq, same issued_at, same fee_paid.
+    assert_eq!(retry, first, "retry must return the original Receipt unchanged");
+
+    // No new fee charged: counter and accounting both unchanged.
+    assert_eq!(attest.receipt_count().query().unwrap(), 1);
+    assert_eq!(attest.collected_fees().query().unwrap(), FLAT_FEE);
+
+    // Caller's balance: paid only gas. The full FLAT_FEE was refunded via
+    // CommandReply::with_value on the retry path.
+    let spent = before - env.system().balance_of(CALLER);
+    assert!(
+        spent < FLAT_FEE,
+        "retry refunded full payment — spend ({}) < FLAT_FEE ({})",
+        spent,
+        FLAT_FEE
+    );
+}
+
+#[tokio::test]
+async fn issue_distinct_callers_same_subject_get_distinct_receipts() {
+    let (program, env) = deploy_program().await;
+    let mut attest = program.attest();
+    let subject = [0xBB; 32];
+
+    // Two different callers needs two minted accounts.
+    let caller_a = CALLER;
+    let caller_b: u64 = 200;
+    env.system().mint_to(caller_b, INITIAL_BALANCE);
+
+    let a = attest
+        .issue(subject, AttestationKind::Action)
+        .with_actor_id(caller_a.into())
+        .with_value(FLAT_FEE)
+        .await
+        .unwrap()
+        .expect("caller A first issue");
+    let b = attest
+        .issue(subject, AttestationKind::Action)
+        .with_actor_id(caller_b.into())
+        .with_value(FLAT_FEE)
+        .await
+        .unwrap()
+        .expect("caller B first issue with same subject");
+
+    assert_eq!(a.seq, 1);
+    assert_eq!(a.caller, caller_a.into());
+    assert_eq!(b.seq, 2);
+    assert_eq!(b.caller, caller_b.into());
+    assert_eq!(a.subject, b.subject, "subject is shared, only caller differs");
+
+    // Both receipts persisted, both fees retained.
+    assert_eq!(attest.receipt_count().query().unwrap(), 2);
+    assert_eq!(attest.collected_fees().query().unwrap(), 2 * FLAT_FEE);
+}
+
+#[tokio::test]
+async fn issue_same_caller_distinct_subjects_get_distinct_receipts() {
+    let (program, _env) = deploy_program().await;
+    let mut attest = program.attest();
+
+    let a = attest
+        .issue([0xC1; 32], AttestationKind::Action)
+        .with_actor_id(CALLER.into())
+        .with_value(FLAT_FEE)
+        .await
+        .unwrap()
+        .expect("first subject");
+    let b = attest
+        .issue([0xC2; 32], AttestationKind::Identity)
+        .with_actor_id(CALLER.into())
+        .with_value(FLAT_FEE)
+        .await
+        .unwrap()
+        .expect("second subject");
+
+    assert_eq!(a.seq, 1);
+    assert_eq!(b.seq, 2);
+    assert_ne!(a.subject, b.subject, "subjects differ");
+    assert_eq!(a.caller, b.caller, "caller is shared");
+    assert_eq!(attest.receipt_count().query().unwrap(), 2);
+    assert_eq!(attest.collected_fees().query().unwrap(), 2 * FLAT_FEE);
+}
+
+#[tokio::test]
+async fn issue_idempotent_retry_with_overpayment_refunds_full_payment() {
+    let (program, env) = deploy_program().await;
+    let mut attest = program.attest();
+    let subject = [0xD; 32];
+
+    // First-time issue at exact fee.
+    attest
+        .issue(subject, AttestationKind::Custom)
+        .with_actor_id(CALLER.into())
+        .with_value(FLAT_FEE)
+        .await
+        .unwrap()
+        .expect("first issue");
+
+    let before = env.system().balance_of(CALLER);
+
+    // Retry with 5x overpayment. The retry path should refund the FULL
+    // 5x payment (not just the excess) because the retry doesn't charge a fee.
+    let attached = 5 * FLAT_FEE;
+    let retry = attest
+        .issue(subject, AttestationKind::Custom)
+        .with_actor_id(CALLER.into())
+        .with_value(attached)
+        .await
+        .unwrap()
+        .expect("retry must succeed regardless of value attached");
+    assert_eq!(retry.seq, 1, "retry returns original seq, not a new one");
+    assert_eq!(retry.fee_paid, FLAT_FEE, "fee_paid is the original fee, not the retry's value");
+    assert_eq!(attest.collected_fees().query().unwrap(), FLAT_FEE);
+
+    // Caller spent ~gas only; full 5*FLAT_FEE refunded.
+    let spent = before - env.system().balance_of(CALLER);
+    assert!(
+        spent < FLAT_FEE,
+        "retry refunded full attached value (spent: {}, attached: {})",
+        spent,
+        attached
+    );
+}
+
+#[tokio::test]
+async fn issue_with_zero_fee_mode_accepts_zero_payment() {
+    let (program, env) = deploy_program().await;
+    let mut attest = program.attest();
+
+    // Owner sets fee to zero. Free-tier mode.
+    attest
+        .set_fee(0)
+        .with_actor_id(OWNER.into())
+        .await
+        .unwrap()
+        .expect("owner can set fee to 0");
+    assert_eq!(attest.required_fee().query().unwrap(), 0);
+
+    // Issue with zero value succeeds (0 >= 0 passes the value guard).
+    let before = env.system().balance_of(CALLER);
+    let r = attest
+        .issue([0xEE; 32], AttestationKind::Action)
+        .with_actor_id(CALLER.into())
+        .with_value(0)
+        .await
+        .unwrap()
+        .expect("zero-fee mode: zero-value Issue succeeds");
+    assert_eq!(r.seq, 1);
+    assert_eq!(r.fee_paid, 0);
+
+    // collected_fees stays at 0; gas-only spend.
+    assert_eq!(attest.collected_fees().query().unwrap(), 0);
+    let spent = before - env.system().balance_of(CALLER);
+    assert!(spent < FLAT_FEE, "free tier: caller spent only gas");
 }


### PR DESCRIPTION
## Summary

Phase 1.5 of the priced-attestation example. **Stacked on PR #29** — base branch is `feat/priced-attestation-example`. Once #29 lands on main, GitHub will auto-retarget this PR to main and the diff narrows to just this commit.

`Issue` now deduplicates on `(caller, subject)`. A retry on the same key returns the existing `Receipt` (byte-identical: same `seq`, `issued_at`, `fee_paid`) and refunds the full new payment via `CommandReply::with_value`. First-time issuance still charges the fee and emits `ReceiptIssued`; the retry path emits a distinct `DuplicateRefunded` event so off-chain indexers can count retries without double-attributing revenue.

This closes the call-shape gap that made retries unsafe in the prior iteration: callers can now blind-retry on RPC timeouts without double-paying. The retry is observably distinct (different event), economically equivalent (full refund), and idempotent at the receipt level (same `seq` returned).

## What changed

**`AttestState`:**
- New field `receipts: BTreeMap<(ActorId, [u8; 32]), Receipt>` — the dedupe map.
- `next_seq` retained as explicit `u64` rather than derived from `receipts.len()`. Rationale: Vara's wasm32 target makes `usize` 32-bit; the seq guarantee should hold beyond `u32::MAX` entries.

**`AttestEvent`:**
- New variant `DuplicateRefunded { caller, subject, refunded }`. Distinct from `ReceiptIssued` so the indexer's revenue counters don't double-count retries.

**`issue()`:**
- Dedupe lookup happens BEFORE the value guard. A retry on a known `(caller, subject)` skips fee math entirely and refunds the full inbound `msg::value()`.
- Self-loop anti-cheat still trumps idempotency: a self-loop call rejects with `Err(SelfLoop)` even if `(program_id, subject)` is in the dedupe map.
- The two paths (retry vs first-time) share a locally-scoped enum so `emit_event` runs after the state borrow drops.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` → 12 passed (existing 7 + 5 new idempotency scenarios):
  - `issue_idempotent_retry_returns_existing_receipt_and_refunds_payment`
  - `issue_distinct_callers_same_subject_get_distinct_receipts`
  - `issue_same_caller_distinct_subjects_get_distinct_receipts`
  - `issue_idempotent_retry_with_overpayment_refunds_full_payment`
  - `issue_with_zero_fee_mode_accepts_zero_payment`
- [x] Codex review (`codex review --base feat/priced-attestation-example`) → no findings, GATE PASS
- [x] **Smoke deploy on testnet** — program `0x2f34568bec3c90da585feceffad0b610ff9606f2550385607bdc8ef8b6b17188` at block 27319301:
  - First `Issue` (subject=`[7;32]`, value=1 VARA) → `Ok(Receipt{seq:1, issued_at:1778265552001, fee_paid:10¹²})`; spent 1.258 VARA.
  - Retry on same `(caller, subject)` with 5 VARA attached → returned **byte-identical** Receipt (same seq, same issued_at), spent 0.259 VARA (gas only — full 5 VARA refunded).
  - `ReceiptCount: 1` (didn't increment), `CollectedFees: 10¹²` (unchanged from first call). Retry contract holds end-to-end.

## Out of scope (next PRs)

- **Self-loop branch** still gtest-untestable (`gtest::System` blocks `with_actor_id(program_id)`). The Phase 2 consumer example (`priced-attestation-consumer/`) will exercise this via a real two-program harness.
- **`ArithmeticOverflow` branch** in source but not gtest-tested — would require priming `next_seq` near `u64::MAX` or `collected_fees` near `u128::MAX`. Possible via direct state injection but not via the public IDL surface.
- **Consumer-side material** (`agent-payment-handshake.md`, `agent-budget-control.md`, `priced-attestation-consumer/`) remains Phase 2 stretch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)