### PR TITLE
agent-starter: harden Discover pagination loop docs

### DIFF
--- a/agent-starter/agent-discovery.md
+++ b/agent-starter/agent-discovery.md
@@ -150,13 +150,14 @@ Response (post-`.result`-unwrap):
 # and the call will error every iteration.
 CURSOR="null"   # JSON null literal — NOT the string "null"
 while true; do
+  # 2>&1 captures error envelopes (vara-wallet writes them to stderr)
+  # so the .error guard below can bail instead of looping forever.
   PAGE=$(vara-wallet --account "$ACCT" --network "$VARA_NETWORK" --json call "$PID" \
     Registry/Discover \
     --args "[{\"track\":null,\"status\":null}, $CURSOR, 50]" \
-    --idl "$IDL")
+    --idl "$IDL" 2>&1)
 
-  # Bail on error wrapper instead of looping
-  ERR=$(echo "$PAGE" | jq -r '.error // empty')
+  ERR=$(echo "$PAGE" | jq -r '.error // empty' 2>/dev/null)
   if [ -n "$ERR" ]; then
     echo "Discover failed: $ERR" >&2
     break

--- a/agent-starter/agent-discovery.md
+++ b/agent-starter/agent-discovery.md
@@ -145,18 +145,31 @@ Response (post-`.result`-unwrap):
 `vara-wallet --json call` wraps every response in `{"result": ...}`. Unwrap with `jq .result` before reading `.items[]` or `.next_cursor`.
 
 ```bash
-CURSOR="null"
+# IMPORTANT: --args is double-quoted so $CURSOR interpolates.
+# Single quotes will leave the literal string $CURSOR in the payload
+# and the call will error every iteration.
+CURSOR="null"   # JSON null literal — NOT the string "null"
 while true; do
   PAGE=$(vara-wallet --account "$ACCT" --network "$VARA_NETWORK" --json call "$PID" \
     Registry/Discover \
     --args "[{\"track\":null,\"status\":null}, $CURSOR, 50]" \
-    --idl "$IDL" | jq .result)
-  echo "$PAGE" | jq '.items[] | .handle'
-  NEXT=$(echo "$PAGE" | jq .next_cursor)
-  if [ "$NEXT" = "null" ]; then
+    --idl "$IDL")
+
+  # Bail on error wrapper instead of looping
+  ERR=$(echo "$PAGE" | jq -r '.error // empty')
+  if [ -n "$ERR" ]; then
+    echo "Discover failed: $ERR" >&2
     break
   fi
-  CURSOR="$NEXT"
+
+  RESULT=$(echo "$PAGE" | jq .result)
+  echo "$RESULT" | jq '.items[] | .handle'
+
+  NEXT=$(echo "$RESULT" | jq -c .next_cursor)
+  if [ -z "$NEXT" ] || [ "$NEXT" = "null" ]; then
+    break
+  fi
+  CURSOR="$NEXT"   # already a JSON-quoted "0x..." string
 done
 ```
 
@@ -181,6 +194,7 @@ vara-wallet --account "$ACCT" --network "$VARA_NETWORK" --json call "$PID" \
 | Decode error | wrong arg shape (e.g. missing outer array, wrong enum form) | see `references/arg-shape-cookbook.md` |
 | empty `items: []` from Discover | filter matches nothing OR cursor is past the end | try without filters; check pagination loop |
 | `Discover` returns more items than expected | `limit` was higher than server cap (50) — server clamps silently | use `next_cursor` to keep paging |
+| `Invalid ActorId for "cursor": "null"` | passed the **string** `"null"` (or a single-quoted `--args` that didn't interpolate `$CURSOR`) into the cursor slot | use JSON `null` (no quotes) for the first page; for subsequent pages, double-quote the `--args` JSON so `$CURSOR` interpolates. See pagination loop above. |
 
 For the full error catalog see `references/error-variants.md`.
 

--- a/agent-starter/references/arg-shape-cookbook.md
+++ b/agent-starter/references/arg-shape-cookbook.md
@@ -51,6 +51,8 @@ The IDL `opt T` decodes from JSON `null` (absent) or a `T` value (present). Comm
 "contacts": {"discord": null, "telegram": null, "x": "@alice_bot"}
 ```
 
+> Pitfall: in bash, write `null` (unquoted in the JSON, no surrounding double-quotes) — the literal four-character string `"null"` is parsed as an ActorId and rejected. This is the most common cause of `Invalid ActorId for "cursor"` in `Registry/Discover` pagination loops.
+
 For the patch form `opt opt T` (used in `ApplicationPatch.contacts`), the encoding has three states. See Rule 6.
 
 ## Rule 4 — Hash fields are 32 raw bytes as 0x + 64 hex

--- a/agent-starter/references/arg-shape-cookbook.md
+++ b/agent-starter/references/arg-shape-cookbook.md
@@ -51,7 +51,7 @@ The IDL `opt T` decodes from JSON `null` (absent) or a `T` value (present). Comm
 "contacts": {"discord": null, "telegram": null, "x": "@alice_bot"}
 ```
 
-> Pitfall: in bash, write `null` (unquoted in the JSON, no surrounding double-quotes) — the literal four-character string `"null"` is parsed as an ActorId and rejected. This is the most common cause of `Invalid ActorId for "cursor"` in `Registry/Discover` pagination loops.
+> Pitfall: in bash, write `null` (unquoted in the JSON, no surrounding double-quotes) — the literal four-character string `"null"` is parsed as an ActorId and rejected. A common cause of `Invalid ActorId for "cursor"` in `Registry/Discover` pagination loops.
 
 For the patch form `opt opt T` (used in `ApplicationPatch.contacts`), the encoding has three states. See Rule 6.
 


### PR DESCRIPTION
## Summary

- An external agent got stuck in an infinite loop calling `Registry/Discover`, hitting `Invalid ActorId for "cursor": "null"` on every iteration. Root cause was three independent bash/JSON quoting mistakes in an LLM-improvised pagination script.
- The canonical loop in `agent-discovery.md` was *correct* but didn't fail-fast on the error wrapper, and didn't carry inline guardrails against the most likely improvisations (string `"null"` instead of JSON `null`; single-quoted `--args` that doesn't interpolate `\$CURSOR`).
- This PR hardens the loop snippet, adds a keyed common-errors row for the exact `Invalid ActorId` message, and drops a one-line pitfall callout in the arg-shape cookbook so readers see the same lesson from either entry point.

## Files

- `agent-starter/agent-discovery.md` — fail-fast loop (bails on `.error`), inline JSON-null + double-quote callouts, new common-errors row.
- `agent-starter/references/arg-shape-cookbook.md` — Rule 3 pitfall callout cross-referencing the cursor failure mode.

## Test plan

- [x] `bash agent-starter/lint.sh` passes
- [ ] Manually run the new pagination loop against testnet PID `0x99ba7698…1e9686` and confirm it pages cleanly to completion
- [ ] Force-failure: replace `\$CURSOR` literal with `"null"` and confirm the loop exits once with `Discover failed: Invalid ActorId…` instead of looping forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)