### PR TITLE
indexer: runtime-version cache + concurrency tuning (∼5× faster backfill)

### DIFF
--- a/services/indexer/.env.example
+++ b/services/indexer/.env.example
@@ -11,6 +11,10 @@ VARA_RPC_URL=wss://testnet.vara.network
 
 # Database.
 DATABASE_URL=postgres://indexer:indexer@localhost:5433/indexer
+# Postgres pool size. Headroom for handler writes during backfill
+# (sequential per batch) + concurrent rollup queries. Bump if you raise
+# PROCESSOR_BACKFILL_FETCH_CONCURRENCY past several hundred.
+DATABASE_POOL_MAX=20
 
 # API.
 API_PORT=4350

--- a/services/indexer/.env.example
+++ b/services/indexer/.env.example
@@ -23,7 +23,10 @@ PROCESSOR_RECONNECT_MAX_MS=60000
 # Set to 250 only for local/dev runs against a pruned RPC.
 PROCESSOR_PRUNED_RPC_BACKFILL_DEPTH=0
 # Fetch historical blocks in parallel, then apply them to Postgres in order.
-PROCESSOR_BACKFILL_FETCH_CONCURRENCY=10
+# Bench (wss://testnet-archive.vara.network, fetch-only): c=10→23,
+# c=50→~90, c=200→~170, c=500→~205 blk/s. Diminishing returns past ~50
+# when real handlers are running (DB pool max=10 becomes the next limit).
+PROCESSOR_BACKFILL_FETCH_CONCURRENCY=50
 # Periodic belt-and-suspenders runtime-version validation. Every N blocks,
 # bypass the cache and confirm the on-chain runtime still matches; mismatches
 # log critical and reset the cache. Set 0 to disable.

--- a/services/indexer/.env.example
+++ b/services/indexer/.env.example
@@ -24,6 +24,10 @@ PROCESSOR_RECONNECT_MAX_MS=60000
 PROCESSOR_PRUNED_RPC_BACKFILL_DEPTH=0
 # Fetch historical blocks in parallel, then apply them to Postgres in order.
 PROCESSOR_BACKFILL_FETCH_CONCURRENCY=10
+# Periodic belt-and-suspenders runtime-version validation. Every N blocks,
+# bypass the cache and confirm the on-chain runtime still matches; mismatches
+# log critical and reset the cache. Set 0 to disable.
+PROCESSOR_RUNTIME_REVALIDATE_EVERY_N_BLOCKS=1000
 
 # Logging.
 LOG_LEVEL=info

--- a/services/indexer/scripts/bench-backfill.ts
+++ b/services/indexer/scripts/bench-backfill.ts
@@ -1,0 +1,40 @@
+// Bounded backfill benchmark. Measures fetch+decode cost only (no handler DB
+// writes) so the comparison isolates the runtime-version cache impact.
+// Usage: VARA_RPC_URL=wss://testnet-archive.vara.network \
+//   tsx scripts/bench-backfill.ts <numBlocks>
+import { createProcessor } from "../src/processor.js";
+import { requireProcessorConfig } from "../src/config.js";
+import type { BlockContext } from "../src/helpers/types.js";
+
+const numBlocks = Number.parseInt(process.argv[2] ?? "500", 10);
+if (!Number.isFinite(numBlocks) || numBlocks <= 0) {
+  console.error("usage: tsx scripts/bench-backfill.ts <numBlocks>");
+  process.exit(1);
+}
+
+const processorConfig = requireProcessorConfig();
+
+// No-op onBlock — we are measuring fetch cost only.
+const processor = await createProcessor({
+  onBlock: async (_ctx: BlockContext) => {},
+});
+
+const startBlock = processorConfig.startBlock;
+const endBlock = startBlock + numBlocks - 1;
+const actualStart = await processor.resumePoint();
+
+console.log(`[bench] range ${actualStart}..${endBlock} (${endBlock - actualStart + 1} blocks; configured numBlocks=${numBlocks} from start=${startBlock})`);
+console.log(`[bench] rpc=${processorConfig.varaRpcUrl}`);
+console.log(`[bench] fetch_concurrency=${processorConfig.processorBackfillFetchConcurrency}`);
+
+const t0 = Date.now();
+await processor.runBackfill(endBlock);
+const elapsedMs = Date.now() - t0;
+
+const actualBlocks = endBlock - actualStart + 1;
+const msPerBlock = elapsedMs / actualBlocks;
+console.log(`[bench] DONE ${actualBlocks} blocks in ${elapsedMs}ms`);
+console.log(`[bench] ${msPerBlock.toFixed(1)}ms/block   (${(1000 / msPerBlock).toFixed(2)} blk/s)`);
+
+await processor.stop();
+process.exit(0);

--- a/services/indexer/scripts/bench-backfill.ts
+++ b/services/indexer/scripts/bench-backfill.ts
@@ -2,9 +2,16 @@
 // writes) so the comparison isolates the runtime-version cache impact.
 // Usage: VARA_RPC_URL=wss://testnet-archive.vara.network \
 //   tsx scripts/bench-backfill.ts <numBlocks>
-import { createProcessor } from "../src/processor.js";
-import { requireProcessorConfig } from "../src/config.js";
-import type { BlockContext } from "../src/helpers/types.js";
+//
+// Cursor-write safety: this script auto-sets PROCESSOR_DISABLE_CURSOR_WRITES
+// so a fetch-only run against any DATABASE_URL never advances processor_cursor
+// without writing projections. Set PROCESSOR_DISABLE_CURSOR_WRITES=false
+// explicitly to override (not recommended). The env var is set BEFORE the
+// dynamic imports below, since static imports are hoisted in ESM and config.ts
+// reads env at module evaluation.
+
+process.env.PROCESSOR_DISABLE_CURSOR_WRITES =
+  process.env.PROCESSOR_DISABLE_CURSOR_WRITES ?? "true";
 
 const numBlocks = Number.parseInt(process.argv[2] ?? "500", 10);
 if (!Number.isFinite(numBlocks) || numBlocks <= 0) {
@@ -12,7 +19,18 @@ if (!Number.isFinite(numBlocks) || numBlocks <= 0) {
   process.exit(1);
 }
 
+const { createProcessor } = await import("../src/processor.js");
+const { requireProcessorConfig } = await import("../src/config.js");
+type BlockContext = import("../src/helpers/types.js").BlockContext;
+
 const processorConfig = requireProcessorConfig();
+
+if (!processorConfig.processorDisableCursorWrites) {
+  console.error(
+    "[bench] WARNING: PROCESSOR_DISABLE_CURSOR_WRITES is not true; this run WILL advance processor_cursor in:",
+    processorConfig.databaseUrl,
+  );
+}
 
 // No-op onBlock — we are measuring fetch cost only.
 const processor = await createProcessor({
@@ -23,9 +41,14 @@ const startBlock = processorConfig.startBlock;
 const endBlock = startBlock + numBlocks - 1;
 const actualStart = await processor.resumePoint();
 
-console.log(`[bench] range ${actualStart}..${endBlock} (${endBlock - actualStart + 1} blocks; configured numBlocks=${numBlocks} from start=${startBlock})`);
+console.log(
+  `[bench] range ${actualStart}..${endBlock} (${endBlock - actualStart + 1} blocks; configured numBlocks=${numBlocks} from start=${startBlock})`,
+);
 console.log(`[bench] rpc=${processorConfig.varaRpcUrl}`);
 console.log(`[bench] fetch_concurrency=${processorConfig.processorBackfillFetchConcurrency}`);
+console.log(
+  `[bench] cursor_writes_disabled=${processorConfig.processorDisableCursorWrites}`,
+);
 
 const t0 = Date.now();
 await processor.runBackfill(endBlock);

--- a/services/indexer/src/config.ts
+++ b/services/indexer/src/config.ts
@@ -49,9 +49,16 @@ export const config = {
   processorReconnectMaxMs: optionalInt("PROCESSOR_RECONNECT_MAX_MS", 60_000),
   processorPrunedRpcBackfillDepth: optionalInt("PROCESSOR_PRUNED_RPC_BACKFILL_DEPTH", 0),
   processorBackfillFetchConcurrency: optionalInt("PROCESSOR_BACKFILL_FETCH_CONCURRENCY", 50),
+  databasePoolMax: optionalInt("DATABASE_POOL_MAX", 20),
   processorRuntimeRevalidateEveryNBlocks: optionalInt(
     "PROCESSOR_RUNTIME_REVALIDATE_EVERY_N_BLOCKS",
     1000,
+  ),
+  // Debug-only: force a specific block to be tagged as CodeUpdated so the
+  // drain path can be exercised without a real runtime upgrade. 0 = off.
+  processorSyntheticCodeUpdatedAtBlock: optionalInt(
+    "PROCESSOR_SYNTHETIC_CODE_UPDATED_AT_BLOCK",
+    0,
   ),
   logLevel: (optional("LOG_LEVEL", "info") as "debug" | "info" | "warn" | "error"),
 } as const;

--- a/services/indexer/src/config.ts
+++ b/services/indexer/src/config.ts
@@ -48,7 +48,7 @@ export const config = {
   processorReconnectMinMs: optionalInt("PROCESSOR_RECONNECT_MIN_MS", 5_000),
   processorReconnectMaxMs: optionalInt("PROCESSOR_RECONNECT_MAX_MS", 60_000),
   processorPrunedRpcBackfillDepth: optionalInt("PROCESSOR_PRUNED_RPC_BACKFILL_DEPTH", 0),
-  processorBackfillFetchConcurrency: optionalInt("PROCESSOR_BACKFILL_FETCH_CONCURRENCY", 10),
+  processorBackfillFetchConcurrency: optionalInt("PROCESSOR_BACKFILL_FETCH_CONCURRENCY", 50),
   processorRuntimeRevalidateEveryNBlocks: optionalInt(
     "PROCESSOR_RUNTIME_REVALIDATE_EVERY_N_BLOCKS",
     1000,

--- a/services/indexer/src/config.ts
+++ b/services/indexer/src/config.ts
@@ -49,6 +49,10 @@ export const config = {
   processorReconnectMaxMs: optionalInt("PROCESSOR_RECONNECT_MAX_MS", 60_000),
   processorPrunedRpcBackfillDepth: optionalInt("PROCESSOR_PRUNED_RPC_BACKFILL_DEPTH", 0),
   processorBackfillFetchConcurrency: optionalInt("PROCESSOR_BACKFILL_FETCH_CONCURRENCY", 10),
+  processorRuntimeRevalidateEveryNBlocks: optionalInt(
+    "PROCESSOR_RUNTIME_REVALIDATE_EVERY_N_BLOCKS",
+    1000,
+  ),
   logLevel: (optional("LOG_LEVEL", "info") as "debug" | "info" | "warn" | "error"),
 } as const;
 

--- a/services/indexer/src/config.ts
+++ b/services/indexer/src/config.ts
@@ -60,6 +60,11 @@ export const config = {
     "PROCESSOR_SYNTHETIC_CODE_UPDATED_AT_BLOCK",
     0,
   ),
+  // Debug-only: skip processor_cursor writes. The bench script sets this so
+  // a fetch-only benchmark against any DATABASE_URL can't accidentally
+  // advance the production cursor without writing projections.
+  processorDisableCursorWrites:
+    (process.env.PROCESSOR_DISABLE_CURSOR_WRITES ?? "").toLowerCase() === "true",
   logLevel: (optional("LOG_LEVEL", "info") as "debug" | "info" | "warn" | "error"),
 } as const;
 

--- a/services/indexer/src/helpers/types.ts
+++ b/services/indexer/src/helpers/types.ts
@@ -33,6 +33,10 @@ export interface BlockContext {
   substrateBlockHash: Hex;
   substrateBlockTs: bigint; // ms
   events: GearEvent[];
+  /** True if this block contained `system.CodeUpdated` — the runtime-version
+   *  cache must be invalidated and any pre-fetched successor blocks discarded,
+   *  since they were decoded against the now-stale registry. */
+  containsCodeUpdated: boolean;
 }
 
 export function isUserMessageSent(e: GearEvent): e is UserMessageSentEvent {

--- a/services/indexer/src/model/db.ts
+++ b/services/indexer/src/model/db.ts
@@ -6,7 +6,7 @@ import * as schema from "./schema.js";
 
 const pool = new pg.Pool({
   connectionString: config.databaseUrl,
-  max: 10,
+  max: config.databasePoolMax,
 });
 
 export const db = drizzle(pool, { schema });

--- a/services/indexer/src/processor.ts
+++ b/services/indexer/src/processor.ts
@@ -27,9 +27,17 @@ export interface ProcessorHooks {
   onBlock: (ctx: BlockContext) => Promise<void>;
 }
 
+// polkadot.js exposes apiAt.runtimeVersion as `RuntimeVersionPartial` at runtime,
+// but its `api.at(blockHash, knownVersion)` parameter is typed as `RuntimeVersion`.
+// The internal cache lookup (_getBlockRegistryViaVersion) only inspects
+// specName/specVersion, both of which the partial type has. Use the api.at
+// parameter type as the cache type and cast at the discovery boundary.
+type CachedRuntimeVersion = NonNullable<Parameters<ApiPromise["at"]>[1]>;
+
 export async function createProcessor(hooks: ProcessorHooks) {
   const config = requireProcessorConfig();
   const backfillFetchConcurrency = Math.max(1, config.processorBackfillFetchConcurrency);
+  const revalidateEveryN = Math.max(0, config.processorRuntimeRevalidateEveryNBlocks);
   const provider = new WsProvider(config.varaRpcUrl);
   let stopped = false;
   let stopReason: Error | null = null;
@@ -71,6 +79,43 @@ export async function createProcessor(hooks: ProcessorHooks) {
 
   const targetProgramIdLower = config.programId.toLowerCase();
 
+  // Runtime-version cache. Anchored to a specific historical block, NOT the
+  // node's current head — initializing from `api.rpc.state.getRuntimeVersion()`
+  // (unqualified) would silently mis-decode historical events on a chain that
+  // has had a runtime upgrade between then and now. Discovery happens on the
+  // first block of each run via api.at(blockHash) without knownVersion, which
+  // populates polkadot.js's internal #registries cache and lets every
+  // subsequent call short-circuit `state_getRuntimeVersion`.
+  let runtimeVersion: CachedRuntimeVersion | undefined = undefined;
+  // Counter for telemetry / verification. Increments on every slow-path
+  // (no-knownVersion) discovery call.
+  let runtimeDiscoveryCount = 0;
+  // Tracks blocks applied since the last revalidation probe. Reset every
+  // `revalidateEveryN` applied blocks.
+  let blocksSinceRevalidate = 0;
+
+  async function discoverRuntimeAt(blockHash: Hex): Promise<void> {
+    // Slow path: forces polkadot.js to fetch chain.getHeader + state.getRuntimeVersion
+    // for this hash (see @polkadot/api/base/Init.js:_getBlockRegistryViaHash).
+    // After this call, the resolved (specName, specVersion) lives in the
+    // #registries array and matches against `api.at(blockHash, runtimeVersion)`
+    // hit the fast path.
+    const apiAt = await api.at(blockHash);
+    runtimeVersion = apiAt.runtimeVersion as CachedRuntimeVersion;
+    runtimeDiscoveryCount += 1;
+    log.info("runtime discovered", {
+      blockHash,
+      specName: runtimeVersion.specName.toString(),
+      specVersion: runtimeVersion.specVersion.toNumber(),
+      discoveryCount: runtimeDiscoveryCount,
+    });
+  }
+
+  function isPrunedBlockError(error: unknown): boolean {
+    const msg = String(error);
+    return msg.includes("State already discarded") || msg.includes("Unknown Block");
+  }
+
   // Normalize ActorId strings to lowercase hex. Gear events surface addresses
   // in mixed formats:
   //   Gear.MessageQueued's source is SS58 (wallet-style extrinsic origin),
@@ -86,19 +131,41 @@ export async function createProcessor(hooks: ProcessorHooks) {
     }
   }
 
-  async function fetchBlockContext(blockNumber: number): Promise<BlockContext> {
+  async function fetchInner(blockNumber: number): Promise<BlockContext> {
     const blockHash = (await api.rpc.chain.getBlockHash(blockNumber)).toHex() as Hex;
-    const apiAt = await api.at(blockHash);
-    const rawEvents = await apiAt.query.system.events();
-    const timestamp = ((await apiAt.query.timestamp.now()) as unknown as { toBigInt(): bigint })
-      .toBigInt();
+
+    if (!runtimeVersion) {
+      // First block of the run, or just after a CodeUpdated drain.
+      await discoverRuntimeAt(blockHash);
+    }
+
+    const apiAt = await api.at(blockHash, runtimeVersion);
+    const [rawEvents, timestampRaw] = await Promise.all([
+      apiAt.query.system.events(),
+      apiAt.query.timestamp.now(),
+    ]);
+    const timestamp = (timestampRaw as unknown as { toBigInt(): bigint }).toBigInt();
 
     const events: GearEvent[] = [];
+    let containsCodeUpdated = false;
     let idx = 0;
     for (const record of rawEvents as unknown as Array<{
       event: { section: string; method: string; data: { toJSON(): unknown } };
     }>) {
       const { section, method, data } = record.event;
+
+      // Detect runtime upgrades. Substrate semantics: `set_code` executes
+      // under the parent runtime, `system.CodeUpdated` is emitted by the same
+      // block under that old runtime, and the new code applies from N+1.
+      // Decoding the current block with the cached (old) version is therefore
+      // correct; processRange will drain any in-flight successor blocks and
+      // rediscover the post-upgrade runtime at N+1.
+      if (section === "system" && method === "CodeUpdated") {
+        containsCodeUpdated = true;
+        idx++;
+        continue;
+      }
+
       if (section !== "gear") {
         idx++;
         continue;
@@ -178,7 +245,28 @@ export async function createProcessor(hooks: ProcessorHooks) {
       substrateBlockHash: blockHash,
       substrateBlockTs: timestamp,
       events,
+      containsCodeUpdated,
     };
+  }
+
+  async function fetchBlockContext(blockNumber: number): Promise<BlockContext> {
+    try {
+      return await fetchInner(blockNumber);
+    } catch (firstErr) {
+      // Pruned blocks must propagate as-is so processRange can skip them.
+      if (isPrunedBlockError(firstErr)) throw firstErr;
+      // Reset cache; the second call will hit discoverRuntimeAt's slow path
+      // and rebuild against actual chain state. If that also fails, surface
+      // both errors via Error.cause so debugging keeps the original context.
+      runtimeVersion = undefined;
+      try {
+        return await fetchInner(blockNumber);
+      } catch (secondErr) {
+        throw new Error(`fetchBlockContext(${blockNumber}) failed twice`, {
+          cause: { firstErr, secondErr },
+        });
+      }
+    }
   }
 
   async function applyBlockContext(ctx: BlockContext): Promise<void> {
@@ -255,15 +343,41 @@ export async function createProcessor(hooks: ProcessorHooks) {
     await processRange(resume, height, "live");
   }
 
-  function isPrunedBlockError(error: unknown): boolean {
-    const msg = String(error);
-    return msg.includes("State already discarded") || msg.includes("Unknown Block");
+  async function maybeRevalidate(blockHash: Hex): Promise<void> {
+    if (revalidateEveryN <= 0) return;
+    blocksSinceRevalidate += 1;
+    if (blocksSinceRevalidate < revalidateEveryN) return;
+    blocksSinceRevalidate = 0;
+    // Bypass the cache: fresh slow-path lookup against this block's hash.
+    const apiAt = await api.at(blockHash);
+    const fresh = apiAt.runtimeVersion as CachedRuntimeVersion;
+    const prev = runtimeVersion;
+    if (
+      prev &&
+      prev.specName.eq(fresh.specName) &&
+      prev.specVersion.eq(fresh.specVersion)
+    ) {
+      log.info("runtime revalidation ok", {
+        blockHash,
+        specVersion: fresh.specVersion.toNumber(),
+      });
+      return;
+    }
+    log.error("runtime revalidation mismatch", {
+      blockHash,
+      prev: prev
+        ? `${prev.specName.toString()}@${prev.specVersion.toNumber()}`
+        : "<none>",
+      fresh: `${fresh.specName.toString()}@${fresh.specVersion.toNumber()}`,
+    });
+    runtimeVersion = fresh;
   }
 
   async function processRange(from: number, to: number, label: "backfill" | "live"): Promise<void> {
     if (from > to) return;
 
-    for (let batchFrom = from; batchFrom <= to; batchFrom += backfillFetchConcurrency) {
+    let batchFrom = from;
+    while (batchFrom <= to) {
       const batchTo = Math.min(to, batchFrom + backfillFetchConcurrency - 1);
       const fetched = await Promise.all(
         Array.from({ length: batchTo - batchFrom + 1 }, async (_, i) => {
@@ -275,6 +389,11 @@ export async function createProcessor(hooks: ProcessorHooks) {
           }
         }),
       );
+
+      // Default: advance past this batch. Overridden below if a CodeUpdated
+      // boundary is found inside the batch — successor results were decoded
+      // against a now-stale registry and must be re-fetched.
+      let nextBatchFrom = batchTo + 1;
 
       for (const result of fetched) {
         if ("error" in result) {
@@ -294,7 +413,26 @@ export async function createProcessor(hooks: ProcessorHooks) {
         if (label === "backfill" && result.block % 50 === 0) {
           log.info("backfill progress", { at: result.block, to });
         }
+
+        if (result.ctx.containsCodeUpdated) {
+          // Drop remaining pre-fetched results in this batch — they were
+          // decoded against the pre-upgrade registry. Reset the cache so the
+          // next fetchBlockContext call rediscovers the post-upgrade runtime
+          // at result.block + 1 via the slow path.
+          log.warn("CodeUpdated detected; draining batch", {
+            at: result.block,
+            dropped: batchTo - result.block,
+          });
+          runtimeVersion = undefined;
+          blocksSinceRevalidate = 0;
+          nextBatchFrom = result.block + 1;
+          break;
+        }
+
+        await maybeRevalidate(result.ctx.substrateBlockHash);
       }
+
+      batchFrom = nextBatchFrom;
     }
   }
 

--- a/services/indexer/src/processor.ts
+++ b/services/indexer/src/processor.ts
@@ -155,9 +155,13 @@ export async function createProcessor(hooks: ProcessorHooks) {
     }
 
     const apiAt = await api.at(blockHash, runtimeVersion);
-    const [rawEvents, timestampRaw] = await Promise.all([
-      apiAt.query.system.events(),
-      apiAt.query.timestamp.now(),
+    // Batch events + timestamp into a single `state_queryStorageAt` RPC.
+    // Previously these were two separate Promise.all'd calls — same wall-clock
+    // sometimes, but doubles the WS message volume. queryMulti folds both
+    // storage reads into one network roundtrip and one server-side lookup.
+    const [rawEvents, timestampRaw] = await apiAt.queryMulti([
+      apiAt.query.system.events,
+      apiAt.query.timestamp.now,
     ]);
     const timestamp = (timestampRaw as unknown as { toBigInt(): bigint }).toBigInt();
 

--- a/services/indexer/src/processor.ts
+++ b/services/indexer/src/processor.ts
@@ -304,6 +304,10 @@ export async function createProcessor(hooks: ProcessorHooks) {
   }
 
   async function updateCursor(blockNumber: number): Promise<void> {
+    // Bench/debug escape hatch — see processorDisableCursorWrites in config.ts.
+    // Prevents a no-op-handler fetch benchmark from advancing the cursor in
+    // whatever DATABASE_URL it happens to be pointed at.
+    if (config.processorDisableCursorWrites) return;
     await db
       .insert(schema.processorCursor)
       .values({
@@ -324,6 +328,9 @@ export async function createProcessor(hooks: ProcessorHooks) {
   }
 
   async function resumePoint(): Promise<number> {
+    // When cursor writes are disabled (bench mode), also ignore cursor reads
+    // so a stale row from a previous real run doesn't skew the start point.
+    if (config.processorDisableCursorWrites) return config.startBlock;
     const cursor = await db
       .select()
       .from(schema.processorCursor)
@@ -373,39 +380,39 @@ export async function createProcessor(hooks: ProcessorHooks) {
     await processRange(resume, height, "live");
   }
 
-  async function maybeRevalidate(blockHash: Hex): Promise<void> {
+  /** Pre-batch revalidation. Runs before any block of the upcoming batch is
+   *  fetched/applied so a missed `CodeUpdated` is detected BEFORE stale
+   *  projections are written and the cursor is advanced. Probes the runtime
+   *  at the first block of the next batch via raw JSON-RPC (api.at would
+   *  short-circuit on the #registries[*].lastBlockHash match set earlier).
+   *
+   *  On mismatch, resets `runtimeVersion=undefined`. The very next
+   *  fetchInner call triggers discoverRuntimeAt's slow path, which both
+   *  refetches the runtime AND repopulates polkadot.js's metadata cache
+   *  against the new (specName, specVersion).
+   */
+  async function maybeRevalidateBeforeBatch(nextBlockNumber: number): Promise<void> {
     if (revalidateEveryN <= 0) return;
-    blocksSinceRevalidate += 1;
     if (blocksSinceRevalidate < revalidateEveryN) return;
     blocksSinceRevalidate = 0;
-    // Bypass the cache via direct JSON-RPC. polkadot.js's api.at(blockHash)
-    // would short-circuit on the #registries[*].lastBlockHash match (set
-    // earlier by fetchInner) and never actually probe the chain — making
-    // the "revalidation" a no-op. state.getRuntimeVersion is a raw RPC and
-    // hits the node every time.
-    const fresh = (await api.rpc.state.getRuntimeVersion(blockHash)) as unknown as CachedRuntimeVersion;
-    const prev = runtimeVersion;
+    if (!runtimeVersion) return; // Nothing to validate yet; fetchInner will discover.
+    const probeHash = (await api.rpc.chain.getBlockHash(nextBlockNumber)).toHex() as Hex;
+    const fresh = (await api.rpc.state.getRuntimeVersion(probeHash)) as unknown as CachedRuntimeVersion;
     if (
-      prev &&
-      prev.specName.eq(fresh.specName) &&
-      prev.specVersion.eq(fresh.specVersion)
+      runtimeVersion.specName.eq(fresh.specName) &&
+      runtimeVersion.specVersion.eq(fresh.specVersion)
     ) {
       log.info("runtime revalidation ok", {
-        blockHash,
+        nextBlock: nextBlockNumber,
         specVersion: fresh.specVersion.toNumber(),
       });
       return;
     }
-    log.error("runtime revalidation mismatch", {
-      blockHash,
-      prev: prev
-        ? `${prev.specName.toString()}@${prev.specVersion.toNumber()}`
-        : "<none>",
+    log.error("runtime revalidation mismatch — missed CodeUpdated; resetting cache", {
+      nextBlock: nextBlockNumber,
+      prev: `${runtimeVersion.specName.toString()}@${runtimeVersion.specVersion.toNumber()}`,
       fresh: `${fresh.specName.toString()}@${fresh.specVersion.toNumber()}`,
     });
-    // Don't trust the freshly-fetched RuntimeVersionPartial verbatim — force
-    // the next fetchInner to rediscover via api.at(blockHash) which also
-    // populates polkadot.js's #registries with the right metadata.
     runtimeVersion = undefined;
   }
 
@@ -414,6 +421,11 @@ export async function createProcessor(hooks: ProcessorHooks) {
 
     let batchFrom = from;
     while (batchFrom <= to) {
+      // Pre-batch: if we've crossed the revalidation threshold, probe the
+      // chain BEFORE fetching this batch so a missed runtime upgrade is
+      // caught before any stale projection is committed.
+      await maybeRevalidateBeforeBatch(batchFrom);
+
       const batchTo = Math.min(to, batchFrom + backfillFetchConcurrency - 1);
       const fetched = await Promise.all(
         Array.from({ length: batchTo - batchFrom + 1 }, async (_, i) => {
@@ -475,7 +487,10 @@ export async function createProcessor(hooks: ProcessorHooks) {
           break;
         }
 
-        await maybeRevalidate(result.ctx.substrateBlockHash);
+        // Count applied blocks toward the next revalidation probe. Probe
+        // itself runs pre-batch (see top of while loop), not post-apply,
+        // so a missed upgrade is caught before stale blocks are written.
+        blocksSinceRevalidate += 1;
       }
 
       batchFrom = nextBatchFrom;

--- a/services/indexer/src/processor.ts
+++ b/services/indexer/src/processor.ts
@@ -259,6 +259,17 @@ export async function createProcessor(hooks: ProcessorHooks) {
       idx++;
     }
 
+    // Debug hook: PROCESSOR_SYNTHETIC_CODE_UPDATED_AT_BLOCK=<N> forces this
+    // block to be tagged as if it contained system.CodeUpdated. Lets us
+    // exercise the drain path without waiting for a real runtime upgrade.
+    if (
+      config.processorSyntheticCodeUpdatedAtBlock > 0 &&
+      blockNumber === config.processorSyntheticCodeUpdatedAtBlock
+    ) {
+      log.warn("synthetic CodeUpdated injected", { block: blockNumber });
+      containsCodeUpdated = true;
+    }
+
     return {
       substrateBlockNumber: blockNumber,
       substrateBlockHash: blockHash,
@@ -367,9 +378,12 @@ export async function createProcessor(hooks: ProcessorHooks) {
     blocksSinceRevalidate += 1;
     if (blocksSinceRevalidate < revalidateEveryN) return;
     blocksSinceRevalidate = 0;
-    // Bypass the cache: fresh slow-path lookup against this block's hash.
-    const apiAt = await api.at(blockHash);
-    const fresh = apiAt.runtimeVersion as CachedRuntimeVersion;
+    // Bypass the cache via direct JSON-RPC. polkadot.js's api.at(blockHash)
+    // would short-circuit on the #registries[*].lastBlockHash match (set
+    // earlier by fetchInner) and never actually probe the chain — making
+    // the "revalidation" a no-op. state.getRuntimeVersion is a raw RPC and
+    // hits the node every time.
+    const fresh = (await api.rpc.state.getRuntimeVersion(blockHash)) as unknown as CachedRuntimeVersion;
     const prev = runtimeVersion;
     if (
       prev &&
@@ -389,7 +403,10 @@ export async function createProcessor(hooks: ProcessorHooks) {
         : "<none>",
       fresh: `${fresh.specName.toString()}@${fresh.specVersion.toNumber()}`,
     });
-    runtimeVersion = fresh;
+    // Don't trust the freshly-fetched RuntimeVersionPartial verbatim — force
+    // the next fetchInner to rediscover via api.at(blockHash) which also
+    // populates polkadot.js's #registries with the right metadata.
+    runtimeVersion = undefined;
   }
 
   async function processRange(from: number, to: number, label: "backfill" | "live"): Promise<void> {
@@ -414,7 +431,8 @@ export async function createProcessor(hooks: ProcessorHooks) {
       // against a now-stale registry and must be re-fetched.
       let nextBatchFrom = batchTo + 1;
 
-      for (const result of fetched) {
+      for (let i = 0; i < fetched.length; i++) {
+        const result = fetched[i]!;
         if ("error" in result) {
           if (isPrunedBlockError(result.error)) {
             log.warn("skipping pruned block", { block: result.block });
@@ -437,10 +455,19 @@ export async function createProcessor(hooks: ProcessorHooks) {
           // Drop remaining pre-fetched results in this batch — they were
           // decoded against the pre-upgrade registry. Reset the cache so the
           // next fetchBlockContext call rediscovers the post-upgrade runtime
-          // at result.block + 1 via the slow path.
+          // at result.block + 1 via the slow path. Classify the dropped
+          // tail by ok/error so we don't silently swallow a real fetch
+          // failure that happened to land after the upgrade boundary.
+          let droppedOk = 0;
+          let droppedErr = 0;
+          for (let j = i + 1; j < fetched.length; j++) {
+            if ("error" in fetched[j]!) droppedErr += 1;
+            else droppedOk += 1;
+          }
           log.warn("CodeUpdated detected; draining batch", {
             at: result.block,
-            dropped: batchTo - result.block,
+            droppedOk,
+            droppedErr,
           });
           runtimeVersion = undefined;
           blocksSinceRevalidate = 0;

--- a/services/indexer/src/processor.ts
+++ b/services/indexer/src/processor.ts
@@ -93,22 +93,37 @@ export async function createProcessor(hooks: ProcessorHooks) {
   // Tracks blocks applied since the last revalidation probe. Reset every
   // `revalidateEveryN` applied blocks.
   let blocksSinceRevalidate = 0;
+  // Single-flight gate. Without this, the first batch of N parallel fetchInner
+  // calls all observe `runtimeVersion === undefined` and each does its own
+  // slow-path discovery — wasting N-1 redundant RPCs at boot and after every
+  // CodeUpdated drain. Verified: with concurrency=10, discoveryCount went 1→10
+  // on the first batch before this gate; with the gate, exactly 1.
+  let runtimeDiscoveryInFlight: Promise<void> | null = null;
 
   async function discoverRuntimeAt(blockHash: Hex): Promise<void> {
-    // Slow path: forces polkadot.js to fetch chain.getHeader + state.getRuntimeVersion
-    // for this hash (see @polkadot/api/base/Init.js:_getBlockRegistryViaHash).
-    // After this call, the resolved (specName, specVersion) lives in the
-    // #registries array and matches against `api.at(blockHash, runtimeVersion)`
-    // hit the fast path.
-    const apiAt = await api.at(blockHash);
-    runtimeVersion = apiAt.runtimeVersion as CachedRuntimeVersion;
-    runtimeDiscoveryCount += 1;
-    log.info("runtime discovered", {
-      blockHash,
-      specName: runtimeVersion.specName.toString(),
-      specVersion: runtimeVersion.specVersion.toNumber(),
-      discoveryCount: runtimeDiscoveryCount,
-    });
+    if (runtimeVersion) return;
+    if (!runtimeDiscoveryInFlight) {
+      runtimeDiscoveryInFlight = (async () => {
+        // Slow path: forces polkadot.js to fetch chain.getHeader +
+        // state.getRuntimeVersion for this hash (see
+        // @polkadot/api/base/Init.js:_getBlockRegistryViaHash). After this
+        // call, the resolved (specName, specVersion) lives in the #registries
+        // array and matches against api.at(blockHash, runtimeVersion) hit
+        // the fast path.
+        const apiAt = await api.at(blockHash);
+        runtimeVersion = apiAt.runtimeVersion as CachedRuntimeVersion;
+        runtimeDiscoveryCount += 1;
+        log.info("runtime discovered", {
+          blockHash,
+          specName: runtimeVersion.specName.toString(),
+          specVersion: runtimeVersion.specVersion.toNumber(),
+          discoveryCount: runtimeDiscoveryCount,
+        });
+      })().finally(() => {
+        runtimeDiscoveryInFlight = null;
+      });
+    }
+    await runtimeDiscoveryInFlight;
   }
 
   function isPrunedBlockError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

Backfill performance investigation that started from the user-reported "1.3 s/block" symptom. Three layered fixes on top of #(`86c5bae parallel refill indexer`):

- **Anchor the runtime-version cache to the actual historical block.** Initializing from `api.rpc.state.getRuntimeVersion()` (head) would silently mis-decode old events across a runtime upgrade. Discovery now runs once via `api.at(blockHash)` slow-path against the first block of the run; subsequent blocks short-circuit `state_getRuntimeVersion` via `api.at(hash, knownVersion)` (`@polkadot/api/base/Init.js:168-176`).
- **`system.CodeUpdated` drain in `processRange`.** When a parallel batch contains a runtime-upgrade boundary, post-boundary blocks were already decoded against the now-stale registry; we discard them, reset the cache, and rediscover from boundary+1.
- **Single-flight discovery gate.** Caught by bench: at concurrency=10, every parallel `fetchInner` in the first batch saw `runtimeVersion === undefined` and each did its own slow probe (10 probes instead of 1). Synchronous check-and-assign of an in-flight promise serializes the first call.
- **Bump default concurrency 10 → 50.** WS pipelining scales well past 10; the previous default left a ~4× speedup on the table.
- **Batch storage reads** with `apiAt.queryMulti([events, timestamp.now])` → one `state_queryStorageAt` instead of two pipelined calls.
- **Periodic revalidation** (`PROCESSOR_RUNTIME_REVALIDATE_EVERY_N_BLOCKS`, default 1000) catches missed `CodeUpdated` events as a belt-and-suspenders.
- **Retry with `Error.cause`** preserves original failure context on the second-attempt path.

### Bench (fetch-only, 1000 blocks from 27066662, `wss://testnet-archive.vara.network`)

| Configuration | ms/block | blk/s |
|---|---:|---:|
| `86c5bae` `c=10` (no cache) | 50.9 | 19.7 |
| This branch `c=10` | 43.1 | 23.2 |
| This branch `c=50` **(new default)** | 11.3 | 88.6 |
| This branch `c=200` | 5.7 | 174.5 |
| This branch `c=500` | 4.4 | 228.2 |

User's originally-reported 1.3 s/block was almost certainly pre-`86c5bae` serial. At the new default the branch is **~5× faster than `86c5bae` alone** and ~115× faster than the original serial baseline. Operators can crank `PROCESSOR_BACKFILL_FETCH_CONCURRENCY` higher on beefier infra (DB pool max=10 becomes the next bottleneck for real-handler runs).

### Codex review

`/codex review` flagged 5 critical correctness issues in the initial draft that are addressed in this PR:
- Wrong cache anchor (head-runtime vs first-block runtime) → fixed via `discoverRuntimeAt`.
- Parallel-batch + `CodeUpdated` race → fixed via the drain path in `processRange`.
- Silent SCALE mis-decode → mitigated via periodic revalidation.
- Error context masked by retry → fixed via `Error.cause`.
- Racy `getRuntimeVersion()` for live mode → not used; we always anchor to a block hash.

## Test plan

- [x] `npm run typecheck` clean
- [x] Bench script at `scripts/bench-backfill.ts` — re-runnable for future perf work
- [x] Slow-path discovery counter == 1 over a stable range (verified)
- [x] Concurrency sweep 1 → 500 (numbers above)
- [ ] Correctness diff: serial vs parallel `pg_dump` of an identical block range (not run yet — recommend running before merge if reviewer wants the extra signal)
- [ ] Synthetic `containsCodeUpdated=true` injection to exercise the drain path (not exercised on testnet, which has had no runtime upgrades during the indexed window)
- [ ] API GraphQL `totalCount` smoke before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)