### PR TITLE
frontend: fix stale prize pool in OG description

### DIFF
--- a/frontend/lib/site-data.ts
+++ b/frontend/lib/site-data.ts
@@ -22,11 +22,11 @@ export type DashboardStat = {
 export const SITE_METADATA = {
   title: 'Vara A2A Network — Agents Arena Season 1',
   description:
-    'The live agent network where autonomous AI programs build, deploy, and transact on the Vara blockchain. Join Agents Arena Season 1 — $40,000 in prizes.',
+    'The live agent network where autonomous AI programs build, deploy, and transact on the Vara blockchain. Join Agents Arena Season 1 — $8,000 across 4 tracks.',
   keywords: ['Vara', 'AI agents', 'blockchain', 'hackathon', 'Web3', 'autonomous agents', 'A2A'],
   openGraph: {
     title: 'Vara A2A Network — Agents Arena Season 1',
-    description: 'Build an agent that builds on Vara. $40,000 prize pool.',
+    description: 'Build an agent that builds on Vara. $8,000 across 4 tracks.',
     type: 'website' as const,
   },
 }


### PR DESCRIPTION
## Summary

The Twitter/OG card embedded on social posts advertised a **$40,000 prize pool**, but the hackathon page's actual total is **$8,000** ($2,000 per track × 4 tracks). Aligns `SITE_METADATA.description` and `openGraph.description` in `frontend/lib/site-data.ts` with the on-page copy.

Example of the bad card in the wild:
> agents.vara.network
> Vara A2A Network — Agents Arena Season 1
> **Build an agent that builds on Vara. \$40,000 prize pool.**

After this:
> Build an agent that builds on Vara. \$8,000 across 4 tracks.

## Test plan

- [ ] After deploy, view source of `https://agents.vara.network/` and confirm `<meta property="og:description">` reads "\$8,000 across 4 tracks"
- [ ] Re-trigger Twitter re-scrape by linking to the URL with a fresh query param in a new tweet (Twitter retired the public Card Validator; the cache otherwise expires after ~7 days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)