### PR TITLE
frontend: add Vara A2A favicon

### DIFF
--- a/frontend/app/icon.svg
+++ b/frontend/app/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#0d0d0d"/>
+  <g stroke="#4ade80" stroke-width="2" stroke-linecap="square" fill="none">
+    <path d="M2 22 L8 8 L14 22"/>
+    <line x1="5" y1="16" x2="27" y2="16"/>
+    <path d="M18 22 L24 8 L30 22"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

The site had no favicon — `frontend/public/` had v0 template placeholders that weren't wired anywhere. This drops a brand-aligned SVG at `frontend/app/icon.svg`, which Next App Router auto-injects as `<link rel="icon" type="image/svg+xml" href="/icon.svg">`. No `layout.tsx` change required.

## Design

Two chevron 'A' glyphs joined by a horizontal bar threading through both crossbars, in Vara green (`#4ade80`) on near-black (`#0d0d0d`). Reads as "agent-to-agent" — directly tied to what this network is. Mono / terminal aesthetic per the [Vara brand system](https://docs.vara.network/); deliberately avoids generic-crypto motifs (glowing nodes, hexagons, radial gradients).

Three strokes total, scales cleanly from 16×16 (browser tab) up to 512×512 (PWA install).

```svg
<svg viewBox="0 0 32 32">
  <rect width="32" height="32" rx="6" fill="#0d0d0d"/>
  <g stroke="#4ade80" stroke-width="2" stroke-linecap="square" fill="none">
    <path d="M2 22 L8 8 L14 22"/>     <!-- A -->
    <line x1="5" y1="16" x2="27" y2="16"/>  <!-- 2A link -->
    <path d="M18 22 L24 8 L30 22"/>   <!-- A -->
  </g>
</svg>
```

## Follow-up (not in this PR)

- `frontend/public/apple-icon.png` and `icon-{light,dark}-32x32.png` are stale v0 placeholders and not referenced. Safe to delete.
- A 180×180 `apple-icon.png` matching the new SVG should be generated and dropped at `frontend/app/apple-icon.png` to cover iOS home-screen installs.

## Test plan

- [ ] After deploy, open `https://agents.vara.network/` and confirm the favicon renders in the browser tab
- [ ] View source: `<head>` should contain `<link rel="icon" type="image/svg+xml" href="/icon.svg" ...>` (auto-injected by Next)
- [ ] Verify legibility at 16×16 (browser tab) and 32×32 (bookmark)
- [ ] Hard-reload (Cmd-Shift-R) — browsers cache favicons aggressively

🤖 Generated with [Claude Code](https://claude.com/claude-code)