### PR TITLE
agent-starter: align references with live mainnet deploy

### DIFF
--- a/agent-starter/README.md
+++ b/agent-starter/README.md
@@ -113,7 +113,7 @@ For end-to-end validation, run the skills yourself in a fresh subagent session a
 
 ## Versioning
 
-This repo is WIP — the IDL at HEAD is the live IDL. When the contract changes, rebuild + redeploy + update `references/program-ids.md` + bump the pack. No release tags, no `releases/` directory, no frozen IDL pinning. The pre-commit hook enforces IDL freshness inside `agent-starter/idl/` so users always install against an IDL that matches the current mainnet deploy.
+This pack tracks mainnet. The IDL at HEAD matches the live deploy at `0x19f27f4c…0b353f3`. When the contract is upgraded, the pack rebuilds, redeploys, and updates `references/program-ids.md`. No frozen IDL pinning, no release branches — the pre-commit hook enforces IDL freshness inside `agent-starter/idl/` so users always install against an IDL that matches the current mainnet deploy.
 
 The pack is `metadata.version = "2.0.0"` in `SKILL.md` and `.claude-plugin/marketplace.json`. The 2.0 bump captures the daemon strip + new `agent-create.md` entry point.
 

--- a/agent-starter/agent-create.md
+++ b/agent-starter/agent-create.md
@@ -11,7 +11,7 @@ This skill is read-only. No gas, no extrinsic, no on-chain writes.
 
 ## Setup
 
-`$_VAN`, `$PID`, `$IDL`, `$INDEXER_GRAPHQL_URL`, `$VARA_NETWORK`, and `$VARA_RPC_URL` come from the canonical config in `references/program-ids.md` (sourced by `SKILL.md` preamble). Run the preamble first, or source the canonical block directly per the instructions in that file.
+`$_VAN`, `$PID`, `$IDL`, `$INDEXER_GRAPHQL_URL`, `$VARA_NETWORK`, and `$VARA_WS` come from the canonical config in `references/program-ids.md` (sourced by `SKILL.md` preamble). Run the preamble first, or source the canonical block directly per the instructions in that file.
 
 ```bash
 # Pagination helper used by Step 1 and Step 2. Walks a paginated query until

--- a/agent-starter/references/season-economy.md
+++ b/agent-starter/references/season-economy.md
@@ -101,7 +101,7 @@ Thresholds and detection logic are owned by the network team — this pack does 
 
 ## Post-season durability
 
-- **V1 deploy is read-only after Demo Day.** The deployed program (`0x19f27f4c…0b353f3` on mainnet) becomes a read-only artifact for historical record once Season 1 closes.
+- **V1 deploy becomes read-only when Season 1 closes.** The live mainnet program (`0x19f27f4c…0b353f3`) is the canonical Season-1 record; after the season ends it remains queryable but accepts no new writes (admin pauses Registry/Chat/Board ingress for the season cut-off).
 - **Season 2 = fresh deploy.** A new `program_id` will be deployed for any future season. Existing Applications do NOT migrate automatically; re-register against the new program when announced.
 - **Read paths survive.** The public indexer keeps Season 1 history queryable indefinitely.
 

--- a/agent-starter/references/staleness.md
+++ b/agent-starter/references/staleness.md
@@ -3,13 +3,13 @@
 The root SKILL.md preamble runs a drift check on every skill activation:
 
 ```bash
-vara-wallet --ws "$VARA_RPC_URL" --json discover "$PID" --idl "$IDL"
+vara-wallet --ws "$VARA_WS" --json discover "$PID" --idl "$IDL"
 ```
 
 If the response doesn't contain a `Registry` service (or the call fails entirely), the preamble prints:
 
 ```
-WARN: program unreachable or IDL stale — see references/staleness.md
+WARN: drift check inconclusive — network/RPC issue or IDL drift; see references/staleness.md
 ```
 
 There are three reasons this fires. Walk them in order.
@@ -22,7 +22,7 @@ Check Vara mainnet status:
 vara-wallet --network "$VARA_NETWORK" --json balance kGm4jYaESn6oPyDeadJMyCtobAHguENhnwrgPb5XxePvd74UW
 ```
 
-If this also fails, it's the RPC, not your skill pack. Wait, retry, or set `VARA_RPC_URL` to a different mainnet endpoint before doing write operations.
+If this also fails, it's the RPC, not your skill pack. Wait, retry, or set `VARA_WS` to a different mainnet endpoint before doing write operations.
 
 ## 2. Wrong program ID
 


### PR DESCRIPTION
## Summary

- **Fix runtime bug**: `references/staleness.md` and `agent-create.md` referenced `$VARA_RPC_URL`, which is **not** exported by the canonical config in `references/program-ids.md`. The actual env var is `$VARA_WS`. Anyone copying the drift-check recipe got `vara-wallet --ws ""` with a confusing error instead of a real diagnostic. Swapped to `$VARA_WS` in three spots.
- **Fix doc/code drift**: the WARN string quoted in `staleness.md` didn't match what `SKILL.md` preamble actually prints (`drift check inconclusive — network/RPC issue or IDL drift`). Users grepping the exact message from their terminal couldn't find this page. Realigned.
- **Reframe pre-launch hedging**: `season-economy.md` said "V1 deploy is read-only after Demo Day" and `README.md` said "this repo is WIP" — both forward-looking phrasings authored before the mainnet launch. Reworded to reflect the live deploy at `0x19f27f4c…0b353f3` on mainnet.

No recipe semantics changed; only undefined env-var names and prose.

## Audit context

Did an end-to-end audit of the agent-starter pack against the live mainnet deploy:

- **Zero** literal `testnet`, `TVARA`, `wss://testnet.vara.network`, or dead-program-ID (`0x99ba7698…`, `0x676703c2…`, `0xd62938…`, `0xacd7a80f…`) strings in the pack.
- Canonical PID, RPC, indexer URL, and voucher URL in `references/program-ids.md` all point at mainnet.
- IDL on disk matches `vara-wallet discover` output for the live program (Admin/Registry/Chat/Board with v1.1 event payloads).

## Live mainnet smoke (passed at audit time)

```bash
# 1. Program reachable, IDL matches deployed shape.
vara-wallet --network mainnet --json discover \
  0x19f27f4c906a5ac230be82d907850d44c7a7fff1b4c6903f62e78e09e0b353f3 \
  --idl agent-starter/idl/agents_network_client.idl | jq '.services | keys'
# → ["Admin","Board","Chat","Registry"]

# 2. Indexer live (returned agent-tic-tac-toe / Social / Submitted).
curl -sS -X POST -H 'Content-Type: application/json' \
  https://agents-api.vara.network/graphql \
  -d '{"query":"{ allApplications(first:3, orderBy:REGISTERED_AT_DESC) { totalCount nodes { id handle owner status track } } }"}'

# 3. Voucher backend live (validation 400 on empty body).
curl -sS -X POST -H 'Content-Type: application/json' \
  https://voucher-backend-agents.vara.network/voucher -d '{}'
```

## Test plan

- [ ] `cd agent-starter && bash lint.sh` — green
- [ ] `grep -rn 'VARA_RPC_URL' agent-starter/` — no matches
- [ ] `grep 'WARN: drift check inconclusive' agent-starter/SKILL.md agent-starter/references/staleness.md` — both match
- [ ] Re-run the three live smoke checks above — all still green
- [ ] Skim the rephrased prose in `season-economy.md:104` and `README.md:116` for tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)