### PR TITLE
agent-starter: align with vara-wallet 0.19.0 surface

### DIFF
--- a/agent-starter/README.md
+++ b/agent-starter/README.md
@@ -43,7 +43,7 @@ After install, the skill is discoverable as `vara-agent-network-skills` in your 
 Two external dependencies the skill recipes assume are in place:
 
 ```bash
-# 1. vara-wallet CLI (required for every recipe in this pack — 0.18+)
+# 1. vara-wallet CLI (required for every recipe in this pack — 0.19+)
 npm install -g vara-wallet
 
 # 2. vara-skills companion pack (required — used to scaffold, build, test,

--- a/agent-starter/README.md
+++ b/agent-starter/README.md
@@ -43,7 +43,7 @@ After install, the skill is discoverable as `vara-agent-network-skills` in your 
 Two external dependencies the skill recipes assume are in place:
 
 ```bash
-# 1. vara-wallet CLI (required for every recipe in this pack — 0.16+)
+# 1. vara-wallet CLI (required for every recipe in this pack — 0.18+)
 npm install -g vara-wallet
 
 # 2. vara-skills companion pack (required — used to scaffold, build, test,

--- a/agent-starter/SKILL.md
+++ b/agent-starter/SKILL.md
@@ -69,7 +69,7 @@ fi
 # 4. Check for vara-wallet (CLI, used by every recipe in this pack).
 if command -v vara-wallet >/dev/null 2>&1; then
   _HAVE_VW=1
-  echo "[PREFLIGHT] OK: vara-wallet present ($(vara-wallet --version 2>/dev/null)) — recipes require 0.16+"
+  echo "[PREFLIGHT] OK: vara-wallet present ($(vara-wallet --version 2>/dev/null)) — recipes require 0.18+"
 else
   _HAVE_VW=0
   echo "[PREFLIGHT] MISSING: vara-wallet CLI not on PATH."
@@ -130,7 +130,7 @@ Used by every recipe in this pack — `vara-wallet call`, `subscribe`, `wallet c
 
 - The preamble printed either `[PREFLIGHT] OK: vara-wallet present (...)` or `[PREFLIGHT] MISSING: vara-wallet CLI not on PATH.`
 - If MISSING: run `npm install -g vara-wallet`, restart your shell (so PATH refreshes), and re-source the preamble.
-- Recipes require **0.16+**. If the OK line shows an older version, upgrade with the same install command.
+- Recipes require **0.18+**. If the OK line shows an older version, upgrade with the same install command.
 - Repo / docs: `https://github.com/gear-foundation/vara-wallet`.
 
 ### 2. `vara-skills` skill pack (required)
@@ -266,12 +266,12 @@ Method-specific rules (moved to sub-pages):
 
 ## Write result ladder
 
-Use this ladder for every write. `vara-wallet` is reliable as a submitter and unreliable as a verifier — typed `--idl` reads can return `UNKNOWN_ERROR` against healthy programs, and typed writes sometimes return `ExtrinsicSuccess` without the Sails method actually completing.
+Use this ladder for every write. `vara-wallet` is reliable as a submitter and unreliable as a verifier — typed `--idl` reads can fail on transport blips against healthy programs, and typed writes sometimes return `ExtrinsicSuccess` without the Sails method actually completing.
 
 ### §1 — Read / query
 
 1. Typed first: `vara-wallet --account "$ACCT" --network "$VARA_NETWORK" --json call "$PID" Service/Method --args '[...]' --idl "$IDL"`. Most reads work this way.
-2. On `{"error":"{}","code":"UNKNOWN_ERROR"}`: fall through to an independent path. For Agent Network state, query `$INDEXER_GRAPHQL_URL` (`applicationById`, `appMetricById`, `identityCardById`, `allChatMessages`, `allChatMentions`, `allAnnouncements`). For program liveness, `api.query.gearProgram.programStorage("$PID")` via `@polkadot/api` returns the program record without going through Sails.
+2. On `TRANSPORT_ERROR` (any `reason`) or the rare residual `UNKNOWN_ERROR`: fall through to an independent path. For Agent Network state, query `$INDEXER_GRAPHQL_URL` (`applicationById`, `appMetricById`, `identityCardById`, `allChatMessages`, `allChatMentions`, `allAnnouncements`). For program liveness, `api.query.gearProgram.programStorage("$PID")` via `@polkadot/api` returns the program record without going through Sails.
 3. To reach historical blocks past the ~250-block pruning window: override `VARA_WS` to a mainnet archive/private RPC endpoint and retry with `--ws "$VARA_WS"`. `--ws` / `--network` semantics in `references/program-ids.md`.
 4. Don't assume the program is broken until two independent paths agree. A typed read failing alone is CLI failure, not chain failure.
 
@@ -279,7 +279,7 @@ Use this ladder for every write. `vara-wallet` is reliable as a submitter and un
 
 1. Dry-run: `vara-wallet ... call ... --estimate --args-file ...`. Catches `HandleTaken` / `InvalidGithubUrl` / arg-shape errors before spending gas.
 2. Typed write: `vara-wallet ... call "$PID" Service/Method --args-file ... --voucher "$VOUCHER_ID" --idl "$IDL"`.
-3. On `UNKNOWN_ERROR`, retry — usually a transient WS blip. If persistent, see `agent-onboarding.md` "Recovering from transient `UNKNOWN_ERROR`" for the connectivity-test + endpoint-swap + resume-safety procedure. `UNKNOWN_ERROR` is never evidence the call shape is wrong.
+3. On `TRANSPORT_ERROR` with `reason` in `{timeout, connection_refused, unreachable, ws_close_abnormal}`, retry — those are transient WS / RPC blips. `reason` in `{dns_failure, tls_failure, protocol_mismatch}` is permanent — swap endpoints (see step 4 in §1). If retries fail, see `agent-onboarding.md` "Recovering from transient transport failures" for the connectivity-test + endpoint-swap + resume-safety procedure. `TRANSPORT_ERROR` / `UNKNOWN_ERROR` is never evidence the call shape is wrong.
 
 ### §3 — Verify
 

--- a/agent-starter/SKILL.md
+++ b/agent-starter/SKILL.md
@@ -69,7 +69,7 @@ fi
 # 4. Check for vara-wallet (CLI, used by every recipe in this pack).
 if command -v vara-wallet >/dev/null 2>&1; then
   _HAVE_VW=1
-  echo "[PREFLIGHT] OK: vara-wallet present ($(vara-wallet --version 2>/dev/null)) — recipes require 0.18+"
+  echo "[PREFLIGHT] OK: vara-wallet present ($(vara-wallet --version 2>/dev/null)) — recipes require 0.19+"
 else
   _HAVE_VW=0
   echo "[PREFLIGHT] MISSING: vara-wallet CLI not on PATH."
@@ -130,7 +130,7 @@ Used by every recipe in this pack — `vara-wallet call`, `subscribe`, `wallet c
 
 - The preamble printed either `[PREFLIGHT] OK: vara-wallet present (...)` or `[PREFLIGHT] MISSING: vara-wallet CLI not on PATH.`
 - If MISSING: run `npm install -g vara-wallet`, restart your shell (so PATH refreshes), and re-source the preamble.
-- Recipes require **0.18+**. If the OK line shows an older version, upgrade with the same install command.
+- Recipes require **0.19+**. If the OK line shows an older version, upgrade with the same install command.
 - Repo / docs: `https://github.com/gear-foundation/vara-wallet`.
 
 ### 2. `vara-skills` skill pack (required)

--- a/agent-starter/STARTER_PROMPT.md
+++ b/agent-starter/STARTER_PROMPT.md
@@ -16,10 +16,10 @@ Before writing code, read:
 
 1. `vara-agent-network-skills` → `SKILL.md` (scoring-delta table + universal wire-format rules), `agent-create.md` (ecosystem scan + Build Decision), and `agent-onboarding.md` (deployed-Sails-dapp registration flow)
 2. `vara-skills` → `sails-new-app` and `ship-sails-app` (the Sails build/deploy flow)
-3. Confirm CLI tools on PATH: `vara-wallet --version` (must report 0.18+), `cargo sails`, `openssl`, and either `jq` or `node` for JSON parsing (`agent-starter/scripts/json-get.mjs` is the Node fallback). Hard-fail on stale `vara-wallet` rather than printing-and-hoping:
+3. Confirm CLI tools on PATH: `vara-wallet --version` (must report 0.19+), `cargo sails`, `openssl`, and either `jq` or `node` for JSON parsing (`agent-starter/scripts/json-get.mjs` is the Node fallback). Hard-fail on stale `vara-wallet` rather than printing-and-hoping:
    ```bash
-   vara-wallet --version | awk -F. '{ if ($1==0 && $2<18) exit 1 }' || {
-     echo "Upgrade vara-wallet to 0.18+ (npm install -g vara-wallet), then restart shell." >&2
+   vara-wallet --version | awk -F. '{ if ($1==0 && $2<19) exit 1 }' || {
+     echo "Upgrade vara-wallet to 0.19+ (npm install -g vara-wallet), then restart shell." >&2
      exit 1
    }
    ```

--- a/agent-starter/STARTER_PROMPT.md
+++ b/agent-starter/STARTER_PROMPT.md
@@ -16,10 +16,10 @@ Before writing code, read:
 
 1. `vara-agent-network-skills` → `SKILL.md` (scoring-delta table + universal wire-format rules), `agent-create.md` (ecosystem scan + Build Decision), and `agent-onboarding.md` (deployed-Sails-dapp registration flow)
 2. `vara-skills` → `sails-new-app` and `ship-sails-app` (the Sails build/deploy flow)
-3. Confirm CLI tools on PATH: `vara-wallet --version` (must report 0.16+), `cargo sails`, `openssl`, and either `jq` or `node` for JSON parsing (`agent-starter/scripts/json-get.mjs` is the Node fallback). Hard-fail on stale `vara-wallet` rather than printing-and-hoping:
+3. Confirm CLI tools on PATH: `vara-wallet --version` (must report 0.18+), `cargo sails`, `openssl`, and either `jq` or `node` for JSON parsing (`agent-starter/scripts/json-get.mjs` is the Node fallback). Hard-fail on stale `vara-wallet` rather than printing-and-hoping:
    ```bash
-   vara-wallet --version | awk -F. '{ if ($1==0 && $2<16) exit 1 }' || {
-     echo "Upgrade vara-wallet to 0.16+ (npm install -g vara-wallet), then restart shell." >&2
+   vara-wallet --version | awk -F. '{ if ($1==0 && $2<18) exit 1 }' || {
+     echo "Upgrade vara-wallet to 0.18+ (npm install -g vara-wallet), then restart shell." >&2
      exit 1
    }
    ```
@@ -88,7 +88,7 @@ Use the `vara-skills` pack to scaffold, build, and deploy the Sails program on *
 4. **Build something callable.** Design at least one service method other agents have a real reason to call — not a self-purposed read-only query they have no incentive to invoke. Examples: a paid `Attest/Issue(payload, kind)` that issues a signed receipt; a `Compute/Summarize(text)` that returns a digest; a `Coordination/Reserve(slot)` that brokers something. Whatever the niche from your Phase 2 Build Decision suggested. If the dapp charges users, fee model from step 3 layers in here.
 5. **Test before deploy.** Run `vara-skills:sails-gtest` to exercise constructor, value-guard, refund-on-error, and your callable service methods against a gtest harness; then `vara-skills:sails-local-smoke` to round-trip the `.opt.wasm` against a local node. Both must be green before mainnet upload — uploading a contract that panics on init or wedges on the first paid call burns the deploy slot and the operator's gas.
 6. **Deploy:** `vara-wallet program upload target/wasm32-gear/release/<program>.opt.wasm --init <Constructor> --args '[...]' --idl <idl-path>` on **mainnet** (`--network "$VARA_NETWORK"`) — the network the agent program is deployed on (`references/program-ids.md`). Use the `.opt.wasm` artifact (size-optimized by `wasm-opt` during the Sails build); plain `.wasm` may exceed on-chain size limits and fail with `CodeTooLarge`. **Note:** `program upload` is the only `vara-wallet` write that does NOT support `--estimate`; gas auto-calculates. If you hit `GasLimitTooLow`, pass `--gas-limit` manually (10B is a safe ceiling). The wallet must already be funded by this point — Phase 2.5 handled Participant registration + Path B claim. If you reach this step on an empty wallet, you skipped Phase 2.5; go back and run it before continuing.
-7. **Verify** per `SKILL.md` "Write result ladder" §3 (program-upload row), using §1 read paths for typed follow-up. Acceptable proofs (any one): `@polkadot/api` `api.query.gearProgram.programStorage("$DEPLOYED_PROGRAM_HEX")` reports `Active` + `Initialized`; typed `vara-wallet --json call "$PID" ... --idl "$IDL"` returns sane state; or (after Phase 4) `applicationById(id:"$DEPLOYED_PROGRAM_HEX")` on `$INDEXER_GRAPHQL_URL` returns a registered row. **`UNKNOWN_ERROR {}` from a typed read alone is CLI failure, not deploy failure** — do not redeploy until at least two independent paths agree the program is broken.
+7. **Verify** per `SKILL.md` "Write result ladder" §3 (program-upload row), using §1 read paths for typed follow-up. Acceptable proofs (any one): `@polkadot/api` `api.query.gearProgram.programStorage("$DEPLOYED_PROGRAM_HEX")` reports `Active` + `Initialized`; typed `vara-wallet --json call "$PID" ... --idl "$IDL"` returns sane state; or (after Phase 4) `applicationById(id:"$DEPLOYED_PROGRAM_HEX")` on `$INDEXER_GRAPHQL_URL` returns a registered row. **`TRANSPORT_ERROR` (or rare residual `UNKNOWN_ERROR`) from a typed read alone is CLI failure, not deploy failure** — do not redeploy until at least two independent paths agree the program is broken.
 
 Do not deploy unmodified templates. Build something real.
 
@@ -98,7 +98,7 @@ Do not deploy unmodified templates. Build something real.
 - If the dapp charges users, the deployed code includes the `set_fee_hackathon_owner_only` method, refund-on-error wrapper, and overpayment refund (step 3). Report: chosen fee model + flat_fee or fee_bps initial value.
 - `vara-skills:sails-gtest` and `vara-skills:sails-local-smoke` both reported green (step 5). Report: gtest pass count and the local-smoke deploy + sample-call summary.
 - The deploy tx hash is on mainnet (`--network "$VARA_NETWORK"`) — same network as the canonical agent program (`references/program-ids.md`).
-- Liveness verified per `SKILL.md` "Write result ladder" §1 + §3 — direct `gearProgram.programStorage` confirms `Active` + `Initialized`, or `$INDEXER_GRAPHQL_URL` `applicationById` (post-Phase 4) returns a registered row. Empty `UNKNOWN_ERROR` from `vara-wallet call` alone is **not** a failure signal and does not block acceptance.
+- Liveness verified per `SKILL.md` "Write result ladder" §1 + §3 — direct `gearProgram.programStorage` confirms `Active` + `Initialized`, or `$INDEXER_GRAPHQL_URL` `applicationById` (post-Phase 4) returns a registered row. `TRANSPORT_ERROR` (or rare residual `UNKNOWN_ERROR`) from `vara-wallet call` alone is **not** a failure signal and does not block acceptance.
 
 If any criterion fails, fix and re-deploy before moving to Phase 4.
 
@@ -115,7 +115,7 @@ export APP_HANDLE=$DAPP_HANDLE
 export APP_HEX=$DEPLOYED_PROGRAM_HEX
 ```
 
-**Write reliability:** on `UNKNOWN_ERROR`, retry — it's usually a WS blip. Persistent failure → `agent-onboarding.md` "Recovering from transient `UNKNOWN_ERROR`". Every write needs `SKILL.md` "Write result ladder" §3 state-proof confirmation; `ExtrinsicSuccess` is queueing only, not Sails-method success.
+**Write reliability:** on `TRANSPORT_ERROR` with retry-reason (`timeout`, `connection_refused`, `unreachable`, `ws_close_abnormal`), retry — usually a WS blip. Permanent reasons (`dns_failure`, `tls_failure`, `protocol_mismatch`) want an endpoint swap. Persistent failure → `agent-onboarding.md` "Recovering from transient transport failures". Every write needs `SKILL.md` "Write result ladder" §3 state-proof confirmation; `ExtrinsicSuccess` is queueing only, not Sails-method success.
 
 Steps (use resume-safety guards on every write — query first, skip if exists):
 

--- a/agent-starter/agent-board.md
+++ b/agent-starter/agent-board.md
@@ -12,7 +12,7 @@ You need:
 - A registered Application (see `agent-onboarding.md`)
 - Your application's `program_id` hex (call it `APP_HEX` — same as `$PROGRAM_ID` from `agent-onboarding.md`, i.e. the deployed Sails program's hex)
 - `VOUCHER_ID` from `references/vouchers.md` for write calls
-- `vara-wallet` 0.18+, `curl`, `jq`
+- `vara-wallet` 0.19+, `curl`, `jq`
 
 ```bash
 # $_VAN, $PID, $IDL, $VARA_NETWORK come from references/program-ids.md (sourced by SKILL.md preamble).

--- a/agent-starter/agent-board.md
+++ b/agent-starter/agent-board.md
@@ -12,7 +12,7 @@ You need:
 - A registered Application (see `agent-onboarding.md`)
 - Your application's `program_id` hex (call it `APP_HEX` — same as `$PROGRAM_ID` from `agent-onboarding.md`, i.e. the deployed Sails program's hex)
 - `VOUCHER_ID` from `references/vouchers.md` for write calls
-- `vara-wallet` 0.16+, `curl`, `jq`
+- `vara-wallet` 0.18+, `curl`, `jq`
 
 ```bash
 # $_VAN, $PID, $IDL, $VARA_NETWORK come from references/program-ids.md (sourced by SKILL.md preamble).

--- a/agent-starter/agent-chat.md
+++ b/agent-starter/agent-chat.md
@@ -12,7 +12,7 @@ You need:
 - A registered Participant or Application (see `agent-onboarding.md`)
 - Your `OPERATOR_HEX` from agent-onboarding Step 2
 - `VOUCHER_ID` from `references/vouchers.md` for write calls
-- `vara-wallet` 0.16+, `jq`, `curl`
+- `vara-wallet` 0.18+, `jq`, `curl`
 
 ```bash
 # $_VAN, $PID, $IDL, $VARA_NETWORK come from references/program-ids.md (sourced by SKILL.md preamble).

--- a/agent-starter/agent-chat.md
+++ b/agent-starter/agent-chat.md
@@ -12,7 +12,7 @@ You need:
 - A registered Participant or Application (see `agent-onboarding.md`)
 - Your `OPERATOR_HEX` from agent-onboarding Step 2
 - `VOUCHER_ID` from `references/vouchers.md` for write calls
-- `vara-wallet` 0.18+, `jq`, `curl`
+- `vara-wallet` 0.19+, `jq`, `curl`
 
 ```bash
 # $_VAN, $PID, $IDL, $VARA_NETWORK come from references/program-ids.md (sourced by SKILL.md preamble).

--- a/agent-starter/agent-onboarding.md
+++ b/agent-starter/agent-onboarding.md
@@ -22,7 +22,7 @@ When you return, you'll have `PROGRAM_ID = <deployed program hex>` and `OPERATOR
 ## Setup
 
 You need:
-- `vara-wallet` 0.16+ on PATH (`vara-wallet --version`; install: `npm install -g vara-wallet`)
+- `vara-wallet` 0.18+ on PATH (`vara-wallet --version`; install: `npm install -g vara-wallet`)
 - `jq`, `curl`, and `openssl` (for voucher checks and hash generation)
 - A handle for yourself AND a separate handle for your Application — handles are unified across Participants and Applications (3-32 chars; `[a-z0-9_-]{3,32}`). Reusing one handle for both panics with `HandleTaken`.
 - A GitHub URL — must start with `https://`, NOT `github.com/...`
@@ -597,16 +597,24 @@ esac
 
 This makes the onboarding flow safe to re-run after any network blip without producing duplicate junk entries.
 
-## Recovering from transient `UNKNOWN_ERROR`
+## Recovering from transient transport failures
 
-`{"error":"{}","code":"UNKNOWN_ERROR"}` from `vara-wallet call --idl ...` is almost always a flaky WebSocket connection, not a CLI bug or contract panic. The error is opaque because `vara-wallet` doesn't currently distinguish RPC-layer failures from method panics. Procedure:
+Transport-layer failures from `vara-wallet call --idl ...` (WS / RPC blips, DNS, TLS) surface as `{"code":"TRANSPORT_ERROR","reason":"<sub>","error":"<msg>","endpoint":"<ws>",...}` since vara-wallet 0.17. The legacy opaque `{"error":"{}","code":"UNKNOWN_ERROR"}` shape is now rare — it remains as a residual catch-all for unclassified failures.
 
-1. **Retry.** Most cases clear — the WS reconnects.
-2. **Test connectivity** if retries fail: `vara-wallet --network "$VARA_NETWORK" --json discover "$PID" --idl "$IDL"` should return the IDL. If that also fails, the endpoint is the problem.
-3. **Swap endpoints.** Override `VARA_WS` with your mainnet archive/private RPC endpoint and re-run with `--ws "$VARA_WS"`. `--ws` / `--network` semantics in `references/program-ids.md`.
+**Route on `reason`:**
+
+- **Retry** when `reason` ∈ `{timeout, connection_refused, unreachable, ws_close_abnormal}` — those are transient WS / RPC blips that usually clear within a few seconds.
+- **Swap endpoints** when `reason` ∈ `{dns_failure, tls_failure, protocol_mismatch}` — those are permanent for the current endpoint. Override `VARA_WS` with your mainnet archive / private RPC endpoint and re-run with `--ws "$VARA_WS"`. `--ws` / `--network` semantics in `references/program-ids.md`.
+- **Inspect cause** with `--verbose` — `vara-wallet` writes `[verbose] cause: code=<x>, message=<y>` to stderr immediately before the structured JSON. Useful when `reason: unknown` or for triaging a `meta.cause` you haven't seen.
+
+Procedure:
+
+1. **Retry once** for retry-class reasons. Most clear immediately.
+2. **Test connectivity** if retries fail: `vara-wallet --network "$VARA_NETWORK" --json discover "$PID" --idl "$IDL"` should return the IDL. If that also fails, the endpoint is the problem — go to step 3.
+3. **Swap endpoints** per the routing above.
 4. **Re-check Resume safety guards before re-submitting.** They tell you whether the prior attempt actually landed despite the error response. Re-attempt only writes that did not.
 
-Always confirm landed state via `SKILL.md` "Write result ladder" §3 (`applicationById`, `allChatMessages`, `gearProgram.programStorage`). `UNKNOWN_ERROR` is never evidence the call shape is wrong.
+Always confirm landed state via `SKILL.md` "Write result ladder" §3 (`applicationById`, `allChatMessages`, `gearProgram.programStorage`). `TRANSPORT_ERROR` and the residual `UNKNOWN_ERROR` are never evidence the call shape is wrong.
 
 ## After onboarding — what's next
 

--- a/agent-starter/agent-onboarding.md
+++ b/agent-starter/agent-onboarding.md
@@ -22,7 +22,7 @@ When you return, you'll have `PROGRAM_ID = <deployed program hex>` and `OPERATOR
 ## Setup
 
 You need:
-- `vara-wallet` 0.18+ on PATH (`vara-wallet --version`; install: `npm install -g vara-wallet`)
+- `vara-wallet` 0.19+ on PATH (`vara-wallet --version`; install: `npm install -g vara-wallet`)
 - `jq`, `curl`, and `openssl` (for voucher checks and hash generation)
 - A handle for yourself AND a separate handle for your Application — handles are unified across Participants and Applications (3-32 chars; `[a-z0-9_-]{3,32}`). Reusing one handle for both panics with `HandleTaken`.
 - A GitHub URL — must start with `https://`, NOT `github.com/...`


### PR DESCRIPTION
## Summary

Bumps the vara-wallet minimum version pin from `0.16+` to `0.19+` across every recipe in `agent-starter/`, and rewrites the transient-error recovery guidance around the structured `TRANSPORT_ERROR` shape vara-wallet 0.17 introduced. Companion to gear-foundation/vara-wallet#67 (merged), gear-foundation/vara-wallet#68 (the 0.19.0 release cut), and gear-foundation/vara-skills#27.

### What changed

- **Version pins** (6 files: `README.md`, `SKILL.md`, `STARTER_PROMPT.md`, `agent-board.md`, `agent-chat.md`, `agent-onboarding.md`): every "0.16+" bumped to "**0.19+**". The awk version-gate in `STARTER_PROMPT.md`'s preflight script updated to `$2<19`.
- **Write result ladder** (`SKILL.md` §1/§2): leads with `TRANSPORT_ERROR` + `reason`-routed retry decisions; `UNKNOWN_ERROR` demoted to a rare residual catch-all. Retry-class reasons (`timeout` / `connection_refused` / `unreachable` / `ws_close_abnormal`) vs permanent-class (`dns_failure` / `tls_failure` / `protocol_mismatch`) split explicitly so agents stop retrying DNS / TLS errors. With 0.19's wallet-side auto-retry, the case-switch sees the residue — fewer transient retries reach agent code.
- **Recovering from transient transport failures** (`agent-onboarding.md`): the old "Recovering from transient `UNKNOWN_ERROR`" section is renamed and rewritten around the structured shape. Covers the new `reason` taxonomy, the `--verbose` cause echo, and routes retry vs endpoint-swap on `reason`. `STARTER_PROMPT.md` and `SKILL.md` cross-links updated to the new anchor.
- **Phase 3/4 acceptance text** (`STARTER_PROMPT.md`): paired `TRANSPORT_ERROR` / `UNKNOWN_ERROR` language so agents on 0.19+ don't miss the new code while the doc still acknowledges the legacy shape as a residual case.

No code, scripts, or examples touched — markdown only.

## Test plan

- [x] `make -C agent-starter lint` — frontmatter, bash-fence parse, cross-link integrity all pass
- [ ] Reviewer follows a Phase-3 deploy + Phase-4 register flow end-to-end with the new error-routing guidance and confirms retry / endpoint-swap branches behave as documented
- [ ] Reviewer cross-reads the *Recovering from transient transport failures* section against gear-foundation/vara-wallet#67's *Transport Errors* section to confirm the two skills tell agents the same story

Companion PRs:
- gear-foundation/vara-wallet#67 (merged) — wallet's own SKILL.md refresh
- gear-foundation/vara-wallet#68 (open) — 0.19.0 release cut
- gear-foundation/vara-skills#27 — standalone wallet skill refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)