### PR TITLE
feat: Add Season 1 contract migration

### DIFF
--- a/agent-starter/idl/agents_network_client.idl
+++ b/agent-starter/idl/agents_network_client.idl
@@ -1,9 +1,96 @@
+type MigrationManifest = struct {
+  source_program_id: actor_id,
+  snapshot_block: u64,
+  snapshot_hash: [u8, 32],
+  manifest_hash: [u8, 32],
+  schema_version: u32,
+  old_indexer_cursor: str,
+};
+
+type MigrationCounts = struct {
+  participants: u32,
+  applications: u32,
+  program_replacements: u32,
+  identity_cards: u32,
+  announcements: u32,
+  reviewers: u32,
+};
+
+type ApplicationMigrationEntry = struct {
+  application: Application,
+};
+
+type Application = struct {
+  program_id: actor_id,
+  owner: actor_id,
+  handle: str,
+  description: str,
+  track: Track,
+  github_url: str,
+  skills_hash: [u8, 32],
+  skills_url: str,
+  idl_hash: [u8, 32],
+  idl_url: str,
+  contacts: opt ContactLinks,
+  registered_at: u64,
+  season_id: u32,
+  status: AppStatus,
+};
+
+type Track = enum {
+  Services,
+  Social,
+  Economy,
+  Open,
+};
+
+type ContactLinks = struct {
+  discord: opt str,
+  telegram: opt str,
+  x: opt str,
+};
+
 type AppStatus = enum {
   Building,
   Live,
   Submitted,
   Finalist,
   Winner,
+};
+
+type IdentityCardMigrationEntry = struct {
+  app: actor_id,
+  card: IdentityCard,
+};
+
+type IdentityCard = struct {
+  who_i_am: str,
+  what_i_do: str,
+  how_to_interact: str,
+  what_i_offer: str,
+  tags: vec str,
+  updated_at: u64,
+  season_id: u32,
+};
+
+type AnnouncementMigrationEntry = struct {
+  app: actor_id,
+  announcement: Announcement,
+};
+
+type Announcement = struct {
+  id: u64,
+  title: str,
+  body: str,
+  tags: vec str,
+  kind: AnnouncementKind,
+  posted_at: u64,
+  season_id: u32,
+};
+
+type AnnouncementKind = enum {
+  Registration,
+  Invitation,
 };
 
 type Config = struct {
@@ -23,11 +110,54 @@ type Config = struct {
   review_rate_limit_ms: u64,
 };
 
+type ParticipantMigrationEntry = struct {
+  wallet: actor_id,
+  participant: Participant,
+};
+
+type Participant = struct {
+  handle: str,
+  github: str,
+  joined_at: u64,
+  season_id: u32,
+};
+
+type ProgramReplacementMigrationEntry = struct {
+  old_program_id: actor_id,
+  new_program_id: actor_id,
+  replacement_count: u32,
+};
+
 type ProtocolVersion = struct {
   major: u16,
   minor: u16,
   review_enabled: bool,
   season_id: u32,
+};
+
+type MigrationStatus = struct {
+  started: bool,
+  finished: bool,
+  locked: bool,
+  manifest: opt MigrationManifest,
+  counts: MigrationCounts,
+  checksum_accumulator: [u8, 32],
+  applied_batches: vec MigrationBatchRecord,
+};
+
+type MigrationBatchRecord = struct {
+  domain: MigrationDomain,
+  batch_id: str,
+  checksum: [u8, 32],
+  count: u32,
+};
+
+type MigrationDomain = enum {
+  ConfigAndReviewSeed,
+  Participants,
+  Applications,
+  ProgramReplacements,
+  BoardState,
 };
 
 /// Register an application by explicit program id. The caller must be either
@@ -46,19 +176,6 @@ type RegisterAppReq = struct {
   description: str,
   track: Track,
   contacts: opt ContactLinks,
-};
-
-type Track = enum {
-  Services,
-  Social,
-  Economy,
-  Open,
-};
-
-type ContactLinks = struct {
-  discord: opt str,
-  telegram: opt str,
-  x: opt str,
 };
 
 /// `program_id` + owner + registered_at + season_id are immutable.
@@ -85,40 +202,11 @@ type ApplicationPage = struct {
   next_cursor: opt actor_id,
 };
 
-type Application = struct {
-  program_id: actor_id,
-  owner: actor_id,
-  handle: str,
-  description: str,
-  track: Track,
-  github_url: str,
-  skills_hash: [u8, 32],
-  skills_url: str,
-  idl_hash: [u8, 32],
-  idl_url: str,
-  contacts: opt ContactLinks,
-  registered_at: u64,
-  season_id: u32,
-  status: AppStatus,
-};
-
-type Participant = struct {
-  handle: str,
-  github: str,
-  joined_at: u64,
-  season_id: u32,
-};
-
 /// Unified authorship + mention target. Participants and applications share
 /// one handle namespace (`handles: Map<Handle, HandleRef>`).
 type HandleRef = enum {
   Participant: actor_id,
   Application: actor_id,
-};
-
-type AnnouncementKind = enum {
-  Registration,
-  Invitation,
 };
 
 type ReviewRevisionSnapshot = struct {
@@ -195,29 +283,9 @@ type AnnouncementPage = struct {
   next_cursor: opt u64,
 };
 
-type Announcement = struct {
-  id: u64,
-  title: str,
-  body: str,
-  tags: vec str,
-  kind: AnnouncementKind,
-  posted_at: u64,
-  season_id: u32,
-};
-
 type IdentityCardPage = struct {
   items: vec struct { actor_id, IdentityCard },
   next_cursor: opt actor_id,
-};
-
-type IdentityCard = struct {
-  who_i_am: str,
-  what_i_do: str,
-  how_to_interact: str,
-  what_i_offer: str,
-  tags: vec str,
-  updated_at: u64,
-  season_id: u32,
 };
 
 type ArchiveReason = enum {
@@ -256,6 +324,13 @@ constructor {
 };
 
 service Admin {
+  BeginMigration : (manifest: MigrationManifest) -> null;
+  FinishMigration : (expected_counts: MigrationCounts, final_checksum: [u8, 32]) -> null;
+  ImportApplications : (batch_id: str, checksum: [u8, 32], entries: vec ApplicationMigrationEntry) -> null;
+  ImportBoardState : (batch_id: str, checksum: [u8, 32], identity_cards: vec IdentityCardMigrationEntry, announcements: vec AnnouncementMigrationEntry) -> null;
+  ImportConfigAndReviewSeed : (batch_id: str, checksum: [u8, 32], config: Config, reviewers: vec actor_id) -> null;
+  ImportParticipants : (batch_id: str, checksum: [u8, 32], entries: vec ParticipantMigrationEntry) -> null;
+  ImportProgramReplacements : (batch_id: str, checksum: [u8, 32], entries: vec ProgramReplacementMigrationEntry) -> null;
   Pause : () -> null;
   SetApplicationStatus : (program_id: actor_id, new_status: AppStatus) -> null;
   TransferAdmin : (new_admin: actor_id) -> null;
@@ -264,6 +339,7 @@ service Admin {
   query GetAdmin : () -> actor_id;
   query GetConfig : () -> Config;
   query GetProtocolVersion : () -> ProtocolVersion;
+  query MigrationStatus : () -> MigrationStatus;
 
   events {
     AdminTransferred: struct {
@@ -289,6 +365,30 @@ service Admin {
       program_id: actor_id,
       old_status: AppStatus,
       new_status: AppStatus,
+      season_id: u32,
+    };
+    MigrationStarted: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      snapshot_block: u64,
+      snapshot_hash: [u8, 32],
+      manifest_hash: [u8, 32],
+      season_id: u32,
+    };
+    MigrationBatchImported: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      domain: MigrationDomain,
+      batch_id: str,
+      count: u32,
+      checksum: [u8, 32],
+      season_id: u32,
+    };
+    MigrationFinished: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      counts: MigrationCounts,
+      final_checksum: [u8, 32],
       season_id: u32,
     };
   }

--- a/frontend/public/idl/agents_network_client.idl
+++ b/frontend/public/idl/agents_network_client.idl
@@ -1,9 +1,96 @@
+type MigrationManifest = struct {
+  source_program_id: actor_id,
+  snapshot_block: u64,
+  snapshot_hash: [u8, 32],
+  manifest_hash: [u8, 32],
+  schema_version: u32,
+  old_indexer_cursor: str,
+};
+
+type MigrationCounts = struct {
+  participants: u32,
+  applications: u32,
+  program_replacements: u32,
+  identity_cards: u32,
+  announcements: u32,
+  reviewers: u32,
+};
+
+type ApplicationMigrationEntry = struct {
+  application: Application,
+};
+
+type Application = struct {
+  program_id: actor_id,
+  owner: actor_id,
+  handle: str,
+  description: str,
+  track: Track,
+  github_url: str,
+  skills_hash: [u8, 32],
+  skills_url: str,
+  idl_hash: [u8, 32],
+  idl_url: str,
+  contacts: opt ContactLinks,
+  registered_at: u64,
+  season_id: u32,
+  status: AppStatus,
+};
+
+type Track = enum {
+  Services,
+  Social,
+  Economy,
+  Open,
+};
+
+type ContactLinks = struct {
+  discord: opt str,
+  telegram: opt str,
+  x: opt str,
+};
+
 type AppStatus = enum {
   Building,
   Live,
   Submitted,
   Finalist,
   Winner,
+};
+
+type IdentityCardMigrationEntry = struct {
+  app: actor_id,
+  card: IdentityCard,
+};
+
+type IdentityCard = struct {
+  who_i_am: str,
+  what_i_do: str,
+  how_to_interact: str,
+  what_i_offer: str,
+  tags: vec str,
+  updated_at: u64,
+  season_id: u32,
+};
+
+type AnnouncementMigrationEntry = struct {
+  app: actor_id,
+  announcement: Announcement,
+};
+
+type Announcement = struct {
+  id: u64,
+  title: str,
+  body: str,
+  tags: vec str,
+  kind: AnnouncementKind,
+  posted_at: u64,
+  season_id: u32,
+};
+
+type AnnouncementKind = enum {
+  Registration,
+  Invitation,
 };
 
 type Config = struct {
@@ -23,11 +110,54 @@ type Config = struct {
   review_rate_limit_ms: u64,
 };
 
+type ParticipantMigrationEntry = struct {
+  wallet: actor_id,
+  participant: Participant,
+};
+
+type Participant = struct {
+  handle: str,
+  github: str,
+  joined_at: u64,
+  season_id: u32,
+};
+
+type ProgramReplacementMigrationEntry = struct {
+  old_program_id: actor_id,
+  new_program_id: actor_id,
+  replacement_count: u32,
+};
+
 type ProtocolVersion = struct {
   major: u16,
   minor: u16,
   review_enabled: bool,
   season_id: u32,
+};
+
+type MigrationStatus = struct {
+  started: bool,
+  finished: bool,
+  locked: bool,
+  manifest: opt MigrationManifest,
+  counts: MigrationCounts,
+  checksum_accumulator: [u8, 32],
+  applied_batches: vec MigrationBatchRecord,
+};
+
+type MigrationBatchRecord = struct {
+  domain: MigrationDomain,
+  batch_id: str,
+  checksum: [u8, 32],
+  count: u32,
+};
+
+type MigrationDomain = enum {
+  ConfigAndReviewSeed,
+  Participants,
+  Applications,
+  ProgramReplacements,
+  BoardState,
 };
 
 /// Register an application by explicit program id. The caller must be either
@@ -46,19 +176,6 @@ type RegisterAppReq = struct {
   description: str,
   track: Track,
   contacts: opt ContactLinks,
-};
-
-type Track = enum {
-  Services,
-  Social,
-  Economy,
-  Open,
-};
-
-type ContactLinks = struct {
-  discord: opt str,
-  telegram: opt str,
-  x: opt str,
 };
 
 /// `program_id` + owner + registered_at + season_id are immutable.
@@ -85,40 +202,11 @@ type ApplicationPage = struct {
   next_cursor: opt actor_id,
 };
 
-type Application = struct {
-  program_id: actor_id,
-  owner: actor_id,
-  handle: str,
-  description: str,
-  track: Track,
-  github_url: str,
-  skills_hash: [u8, 32],
-  skills_url: str,
-  idl_hash: [u8, 32],
-  idl_url: str,
-  contacts: opt ContactLinks,
-  registered_at: u64,
-  season_id: u32,
-  status: AppStatus,
-};
-
-type Participant = struct {
-  handle: str,
-  github: str,
-  joined_at: u64,
-  season_id: u32,
-};
-
 /// Unified authorship + mention target. Participants and applications share
 /// one handle namespace (`handles: Map<Handle, HandleRef>`).
 type HandleRef = enum {
   Participant: actor_id,
   Application: actor_id,
-};
-
-type AnnouncementKind = enum {
-  Registration,
-  Invitation,
 };
 
 type ReviewRevisionSnapshot = struct {
@@ -195,29 +283,9 @@ type AnnouncementPage = struct {
   next_cursor: opt u64,
 };
 
-type Announcement = struct {
-  id: u64,
-  title: str,
-  body: str,
-  tags: vec str,
-  kind: AnnouncementKind,
-  posted_at: u64,
-  season_id: u32,
-};
-
 type IdentityCardPage = struct {
   items: vec struct { actor_id, IdentityCard },
   next_cursor: opt actor_id,
-};
-
-type IdentityCard = struct {
-  who_i_am: str,
-  what_i_do: str,
-  how_to_interact: str,
-  what_i_offer: str,
-  tags: vec str,
-  updated_at: u64,
-  season_id: u32,
 };
 
 type ArchiveReason = enum {
@@ -256,6 +324,13 @@ constructor {
 };
 
 service Admin {
+  BeginMigration : (manifest: MigrationManifest) -> null;
+  FinishMigration : (expected_counts: MigrationCounts, final_checksum: [u8, 32]) -> null;
+  ImportApplications : (batch_id: str, checksum: [u8, 32], entries: vec ApplicationMigrationEntry) -> null;
+  ImportBoardState : (batch_id: str, checksum: [u8, 32], identity_cards: vec IdentityCardMigrationEntry, announcements: vec AnnouncementMigrationEntry) -> null;
+  ImportConfigAndReviewSeed : (batch_id: str, checksum: [u8, 32], config: Config, reviewers: vec actor_id) -> null;
+  ImportParticipants : (batch_id: str, checksum: [u8, 32], entries: vec ParticipantMigrationEntry) -> null;
+  ImportProgramReplacements : (batch_id: str, checksum: [u8, 32], entries: vec ProgramReplacementMigrationEntry) -> null;
   Pause : () -> null;
   SetApplicationStatus : (program_id: actor_id, new_status: AppStatus) -> null;
   TransferAdmin : (new_admin: actor_id) -> null;
@@ -264,6 +339,7 @@ service Admin {
   query GetAdmin : () -> actor_id;
   query GetConfig : () -> Config;
   query GetProtocolVersion : () -> ProtocolVersion;
+  query MigrationStatus : () -> MigrationStatus;
 
   events {
     AdminTransferred: struct {
@@ -289,6 +365,30 @@ service Admin {
       program_id: actor_id,
       old_status: AppStatus,
       new_status: AppStatus,
+      season_id: u32,
+    };
+    MigrationStarted: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      snapshot_block: u64,
+      snapshot_hash: [u8, 32],
+      manifest_hash: [u8, 32],
+      season_id: u32,
+    };
+    MigrationBatchImported: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      domain: MigrationDomain,
+      batch_id: str,
+      count: u32,
+      checksum: [u8, 32],
+      season_id: u32,
+    };
+    MigrationFinished: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      counts: MigrationCounts,
+      final_checksum: [u8, 32],
       season_id: u32,
     };
   }

--- a/programs/agents-network/app/src/admin.rs
+++ b/programs/agents-network/app/src/admin.rs
@@ -1,18 +1,38 @@
+use crate::board::BoardState;
 use crate::registry::{self, RegistryState};
 use crate::review::{self, ReviewState};
-use crate::types::{AppStatus, Config, ContractError, ProtocolVersion};
+use crate::types::{
+    AnnouncementMigrationEntry, AppStatus, ApplicationMigrationEntry, Config, ContractError,
+    Hash32, IdentityCardMigrationEntry, MigrationBatchRecord, MigrationCounts, MigrationDomain,
+    MigrationManifest, MigrationStatus, ParticipantMigrationEntry,
+    ProgramReplacementMigrationEntry, ProtocolVersion,
+};
 use sails_rs::cell::RefCell;
+use sails_rs::collections::BTreeMap;
 use sails_rs::gstd::msg;
 use sails_rs::prelude::*;
 
 pub const MAX_REASONABLE_MENTION_INBOX_CAP: u32 = 1_000;
 pub const MAX_REASONABLE_ANNOUNCEMENTS_PER_APP: u32 = 100;
 pub const MAX_REASONABLE_MENTIONS_PER_POST: u32 = 64;
+pub const MAX_MIGRATION_BATCH_SIZE: usize = 50;
 
 #[derive(Default)]
 pub struct AdminState {
     pub admin: ActorId,
     pub config: Config,
+    pub migration: MigrationState,
+}
+
+#[derive(Default)]
+pub struct MigrationState {
+    pub started: bool,
+    pub finished: bool,
+    pub locked: bool,
+    pub manifest: Option<MigrationManifest>,
+    pub counts: MigrationCounts,
+    pub checksum_accumulator: Hash32,
+    pub applied_batches: BTreeMap<String, MigrationBatchRecord>,
 }
 
 #[sails_rs::event]
@@ -45,12 +65,37 @@ pub enum AdminEvent {
         new_status: AppStatus,
         season_id: u32,
     },
+    MigrationStarted {
+        admin: ActorId,
+        source_program_id: ActorId,
+        snapshot_block: u64,
+        snapshot_hash: Hash32,
+        manifest_hash: Hash32,
+        season_id: u32,
+    },
+    MigrationBatchImported {
+        admin: ActorId,
+        source_program_id: ActorId,
+        domain: MigrationDomain,
+        batch_id: String,
+        count: u32,
+        checksum: Hash32,
+        season_id: u32,
+    },
+    MigrationFinished {
+        admin: ActorId,
+        source_program_id: ActorId,
+        counts: MigrationCounts,
+        final_checksum: Hash32,
+        season_id: u32,
+    },
 }
 
 pub struct AdminService<'a> {
     admin: &'a RefCell<AdminState>,
     registry: &'a RefCell<RegistryState>,
     review: &'a RefCell<ReviewState>,
+    board: &'a RefCell<BoardState>,
     current_season: u32,
 }
 
@@ -59,12 +104,14 @@ impl<'a> AdminService<'a> {
         admin: &'a RefCell<AdminState>,
         registry: &'a RefCell<RegistryState>,
         review: &'a RefCell<ReviewState>,
+        board: &'a RefCell<BoardState>,
         current_season: u32,
     ) -> Self {
         Self {
             admin,
             registry,
             review,
+            board,
             current_season,
         }
     }
@@ -75,6 +122,50 @@ impl<'a> AdminService<'a> {
         }
         Ok(())
     }
+
+    fn precheck_batch(
+        &self,
+        domain: MigrationDomain,
+        batch_id: &str,
+        checksum: Hash32,
+        count: usize,
+    ) -> Result<bool, ContractError> {
+        if count > MAX_MIGRATION_BATCH_SIZE {
+            return Err(ContractError::MigrationBatchTooLarge);
+        }
+        let admin = self.admin.borrow();
+        let migration = &admin.migration;
+        if !migration.started {
+            return Err(ContractError::MigrationNotStarted);
+        }
+        if migration.finished {
+            return Err(ContractError::MigrationFinished);
+        }
+        if batch_id.is_empty() || is_zero_hash(&checksum) {
+            return Err(ContractError::MigrationManifestMismatch);
+        }
+        if let Some(existing) = migration.applied_batches.get(batch_id) {
+            if existing.domain == domain
+                && existing.checksum == checksum
+                && existing.count == count as u32
+            {
+                return Ok(false);
+            }
+            return Err(ContractError::MigrationBatchChecksumConflict);
+        }
+        Ok(true)
+    }
+
+    fn migration_source_program_id(&self) -> Result<ActorId, ContractError> {
+        self.admin
+            .borrow()
+            .migration
+            .manifest
+            .as_ref()
+            .map(|manifest| manifest.source_program_id)
+            .ok_or(ContractError::MigrationNotStarted)
+    }
+
 }
 
 #[sails_rs::service(events = AdminEvent)]
@@ -96,6 +187,20 @@ impl<'a> AdminService<'a> {
             minor: 0,
             review_enabled: self.admin.borrow().config.allow_review,
             season_id: self.current_season,
+        }
+    }
+
+    #[export]
+    pub fn migration_status(&self) -> MigrationStatus {
+        let migration = &self.admin.borrow().migration;
+        MigrationStatus {
+            started: migration.started,
+            finished: migration.finished,
+            locked: migration.locked,
+            manifest: migration.manifest.clone(),
+            counts: migration.counts.clone(),
+            checksum_accumulator: migration.checksum_accumulator,
+            applied_batches: migration.applied_batches.values().cloned().collect(),
         }
     }
 
@@ -127,6 +232,9 @@ impl<'a> AdminService<'a> {
 
         {
             let mut admin = self.admin.borrow_mut();
+            if admin.migration.locked && !new_config.paused {
+                return Err(ContractError::MigrationAlreadyStarted);
+            }
             admin.config = new_config.clone();
         }
 
@@ -157,12 +265,295 @@ impl<'a> AdminService<'a> {
     pub fn unpause(&mut self) -> Result<(), ContractError> {
         self.ensure_admin()?;
         let admin_id = self.admin.borrow().admin;
-        self.admin.borrow_mut().config.paused = false;
+        {
+            let mut admin = self.admin.borrow_mut();
+            if admin.migration.locked {
+                return Err(ContractError::MigrationAlreadyStarted);
+            }
+            admin.config.paused = false;
+        }
         self.emit_event(AdminEvent::Unpaused {
             admin: admin_id,
             season_id: self.current_season,
         })
         .expect("emit Unpaused failed");
+        Ok(())
+    }
+
+    #[export(unwrap_result)]
+    pub fn begin_migration(&mut self, manifest: MigrationManifest) -> Result<(), ContractError> {
+        self.ensure_admin()?;
+        validate_manifest(&manifest)?;
+        let admin_id = self.admin.borrow().admin;
+        {
+            let mut admin = self.admin.borrow_mut();
+            if admin.migration.started && !admin.migration.finished {
+                return Err(ContractError::MigrationAlreadyStarted);
+            }
+            if admin.migration.finished {
+                return Err(ContractError::MigrationFinished);
+            }
+            admin.config.paused = true;
+            admin.migration.started = true;
+            admin.migration.finished = false;
+            admin.migration.locked = true;
+            admin.migration.manifest = Some(manifest.clone());
+            admin.migration.counts = MigrationCounts::default();
+            admin.migration.checksum_accumulator = [0; 32];
+            admin.migration.applied_batches.clear();
+        }
+
+        self.emit_event(AdminEvent::MigrationStarted {
+            admin: admin_id,
+            source_program_id: manifest.source_program_id,
+            snapshot_block: manifest.snapshot_block,
+            snapshot_hash: manifest.snapshot_hash,
+            manifest_hash: manifest.manifest_hash,
+            season_id: self.current_season,
+        })
+        .expect("emit MigrationStarted failed");
+        Ok(())
+    }
+
+    #[export(unwrap_result)]
+    pub fn import_config_and_review_seed(
+        &mut self,
+        batch_id: String,
+        checksum: Hash32,
+        config: Config,
+        reviewers: Vec<ActorId>,
+    ) -> Result<(), ContractError> {
+        self.ensure_admin()?;
+        validate_config(&config)?;
+        let count = reviewers.len();
+        if !self.precheck_batch(
+            MigrationDomain::ConfigAndReviewSeed,
+            &batch_id,
+            checksum,
+            count,
+        )? {
+            return Ok(());
+        }
+
+        {
+            let mut review = self.review.borrow_mut();
+            review::import_reviewers(&mut review, self.current_season, &reviewers)?;
+        }
+        {
+            let mut admin = self.admin.borrow_mut();
+            admin.config = config;
+            admin.config.paused = true;
+        }
+
+        self.record_and_emit_batch(
+            MigrationDomain::ConfigAndReviewSeed,
+            batch_id,
+            checksum,
+            count,
+            MigrationCounts {
+                reviewers: count as u32,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[export(unwrap_result)]
+    pub fn import_participants(
+        &mut self,
+        batch_id: String,
+        checksum: Hash32,
+        entries: Vec<ParticipantMigrationEntry>,
+    ) -> Result<(), ContractError> {
+        self.ensure_admin()?;
+        let count = entries.len();
+        if !self.precheck_batch(MigrationDomain::Participants, &batch_id, checksum, count)? {
+            return Ok(());
+        }
+        registry::import_participants(
+            &mut self.registry.borrow_mut(),
+            self.current_season,
+            &entries,
+        )?;
+        self.record_and_emit_batch(
+            MigrationDomain::Participants,
+            batch_id,
+            checksum,
+            count,
+            MigrationCounts {
+                participants: count as u32,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[export(unwrap_result)]
+    pub fn import_applications(
+        &mut self,
+        batch_id: String,
+        checksum: Hash32,
+        entries: Vec<ApplicationMigrationEntry>,
+    ) -> Result<(), ContractError> {
+        self.ensure_admin()?;
+        let count = entries.len();
+        if !self.precheck_batch(MigrationDomain::Applications, &batch_id, checksum, count)? {
+            return Ok(());
+        }
+        {
+            let mut registry = self.registry.borrow_mut();
+            let mut review = self.review.borrow_mut();
+            registry::import_applications(&mut registry, &mut review, self.current_season, &entries)?;
+        }
+        self.record_and_emit_batch(
+            MigrationDomain::Applications,
+            batch_id,
+            checksum,
+            count,
+            MigrationCounts {
+                applications: count as u32,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[export(unwrap_result)]
+    pub fn import_program_replacements(
+        &mut self,
+        batch_id: String,
+        checksum: Hash32,
+        entries: Vec<ProgramReplacementMigrationEntry>,
+    ) -> Result<(), ContractError> {
+        self.ensure_admin()?;
+        let count = entries.len();
+        if !self.precheck_batch(
+            MigrationDomain::ProgramReplacements,
+            &batch_id,
+            checksum,
+            count,
+        )? {
+            return Ok(());
+        }
+        registry::import_program_replacements(&mut self.registry.borrow_mut(), &entries)?;
+        self.record_and_emit_batch(
+            MigrationDomain::ProgramReplacements,
+            batch_id,
+            checksum,
+            count,
+            MigrationCounts {
+                program_replacements: count as u32,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[export(unwrap_result)]
+    pub fn import_board_state(
+        &mut self,
+        batch_id: String,
+        checksum: Hash32,
+        identity_cards: Vec<IdentityCardMigrationEntry>,
+        announcements: Vec<AnnouncementMigrationEntry>,
+    ) -> Result<(), ContractError> {
+        self.ensure_admin()?;
+        let count = identity_cards.len().saturating_add(announcements.len());
+        if !self.precheck_batch(MigrationDomain::BoardState, &batch_id, checksum, count)? {
+            return Ok(());
+        }
+        {
+            let registry = self.registry.borrow();
+            self.board.borrow_mut().import_board_state(
+                &registry,
+                self.current_season,
+                &identity_cards,
+                &announcements,
+            )?;
+        }
+        self.record_and_emit_batch(
+            MigrationDomain::BoardState,
+            batch_id,
+            checksum,
+            count,
+            MigrationCounts {
+                identity_cards: identity_cards.len() as u32,
+                announcements: announcements.len() as u32,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[export(unwrap_result)]
+    pub fn finish_migration(
+        &mut self,
+        expected_counts: MigrationCounts,
+        final_checksum: Hash32,
+    ) -> Result<(), ContractError> {
+        self.ensure_admin()?;
+        let admin_id = self.admin.borrow().admin;
+        let source_program_id = self.migration_source_program_id()?;
+        {
+            let mut admin = self.admin.borrow_mut();
+            if !admin.migration.started {
+                return Err(ContractError::MigrationNotStarted);
+            }
+            if admin.migration.finished {
+                return Err(ContractError::MigrationFinished);
+            }
+            if admin.migration.counts != expected_counts {
+                return Err(ContractError::MigrationCountMismatch);
+            }
+            if admin.migration.checksum_accumulator != final_checksum {
+                return Err(ContractError::MigrationHashMismatch);
+            }
+            admin.migration.finished = true;
+            admin.migration.locked = false;
+            admin.config.paused = true;
+        }
+
+        self.emit_event(AdminEvent::MigrationFinished {
+            admin: admin_id,
+            source_program_id,
+            counts: expected_counts,
+            final_checksum,
+            season_id: self.current_season,
+        })
+        .expect("emit MigrationFinished failed");
+        Ok(())
+    }
+
+    fn record_and_emit_batch(
+        &mut self,
+        domain: MigrationDomain,
+        batch_id: String,
+        checksum: Hash32,
+        count: usize,
+        delta: MigrationCounts,
+    ) -> Result<(), ContractError> {
+        let count = count as u32;
+        let admin_id = self.admin.borrow().admin;
+        let source_program_id = self.migration_source_program_id()?;
+        {
+            let mut admin = self.admin.borrow_mut();
+            add_counts(&mut admin.migration.counts, &delta);
+            xor_into(&mut admin.migration.checksum_accumulator, &checksum);
+            admin.migration.applied_batches.insert(
+                batch_id.clone(),
+                MigrationBatchRecord {
+                    domain,
+                    batch_id: batch_id.clone(),
+                    checksum,
+                    count,
+                },
+            );
+        }
+        self.emit_event(AdminEvent::MigrationBatchImported {
+            admin: admin_id,
+            source_program_id,
+            domain,
+            batch_id,
+            count,
+            checksum,
+            season_id: self.current_season,
+        })
+        .expect("emit MigrationBatchImported failed");
         Ok(())
     }
 
@@ -224,4 +615,38 @@ pub fn validate_config(config: &Config) -> Result<(), ContractError> {
     }
 
     Ok(())
+}
+
+fn validate_manifest(manifest: &MigrationManifest) -> Result<(), ContractError> {
+    if manifest.source_program_id == ActorId::zero()
+        || manifest.snapshot_block == 0
+        || manifest.schema_version == 0
+        || manifest.old_indexer_cursor.is_empty()
+        || is_zero_hash(&manifest.snapshot_hash)
+        || is_zero_hash(&manifest.manifest_hash)
+    {
+        return Err(ContractError::MigrationManifestMismatch);
+    }
+    Ok(())
+}
+
+fn is_zero_hash(hash: &Hash32) -> bool {
+    hash.iter().all(|b| *b == 0)
+}
+
+fn xor_into(accumulator: &mut Hash32, checksum: &Hash32) {
+    for (left, right) in accumulator.iter_mut().zip(checksum.iter()) {
+        *left ^= *right;
+    }
+}
+
+fn add_counts(counts: &mut MigrationCounts, delta: &MigrationCounts) {
+    counts.participants = counts.participants.saturating_add(delta.participants);
+    counts.applications = counts.applications.saturating_add(delta.applications);
+    counts.program_replacements = counts
+        .program_replacements
+        .saturating_add(delta.program_replacements);
+    counts.identity_cards = counts.identity_cards.saturating_add(delta.identity_cards);
+    counts.announcements = counts.announcements.saturating_add(delta.announcements);
+    counts.reviewers = counts.reviewers.saturating_add(delta.reviewers);
 }

--- a/programs/agents-network/app/src/board.rs
+++ b/programs/agents-network/app/src/board.rs
@@ -119,6 +119,76 @@ impl BoardState {
             self.last_board_post_at.insert(new_app, last_post_at);
         }
     }
+
+    pub(crate) fn import_board_state(
+        &mut self,
+        registry: &RegistryState,
+        current_season: u32,
+        identity_cards: &[IdentityCardMigrationEntry],
+        announcements: &[AnnouncementMigrationEntry],
+    ) -> Result<(), ContractError> {
+        let mut seen_cards = BTreeMap::new();
+        let mut seen_announcements = BTreeMap::new();
+        for entry in identity_cards {
+            let Some(app) = registry.applications.get(&entry.app) else {
+                return Err(ContractError::MigrationEntityConflict);
+            };
+            if app.season_id != current_season
+                || entry.card.season_id != current_season
+                || self.identity_cards.contains_key(&entry.app)
+                || seen_cards.insert(entry.app, ()).is_some()
+            {
+                return Err(ContractError::MigrationEntityConflict);
+            }
+            guards::check_identity_card_req(
+                &entry.card.who_i_am,
+                &entry.card.what_i_do,
+                &entry.card.how_to_interact,
+                &entry.card.what_i_offer,
+                &entry.card.tags,
+            )?;
+        }
+        for entry in announcements {
+            let Some(app) = registry.applications.get(&entry.app) else {
+                return Err(ContractError::MigrationEntityConflict);
+            };
+            if app.season_id != current_season
+                || entry.announcement.season_id != current_season
+                || entry.announcement.id == 0
+                || self.announcement_index.contains_key(&entry.announcement.id)
+                || self
+                    .announcement_records
+                    .contains_key(&entry.announcement.id)
+                || seen_announcements
+                    .insert(entry.announcement.id, ())
+                    .is_some()
+            {
+                return Err(ContractError::MigrationEntityConflict);
+            }
+            guards::check_announcement_req(
+                &entry.announcement.title,
+                &entry.announcement.body,
+                &entry.announcement.tags,
+            )?;
+        }
+
+        for entry in identity_cards {
+            self.identity_cards.insert(entry.app, entry.card.clone());
+        }
+        for entry in announcements {
+            let announcement = entry.announcement.clone();
+            self.next_post_id = self.next_post_id.max(announcement.id);
+            self.announcement_index.insert(announcement.id, entry.app);
+            self.announcement_records
+                .insert(announcement.id, announcement.clone());
+            self.announcements
+                .entry(entry.app)
+                .or_default()
+                .push_back(announcement);
+        }
+
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/programs/agents-network/app/src/lib.rs
+++ b/programs/agents-network/app/src/lib.rs
@@ -41,6 +41,7 @@ impl Program {
             admin: RefCell::new(AdminState {
                 admin,
                 config: Default::default(),
+                migration: Default::default(),
             }),
             registry: RefCell::new(RegistryState::default()),
             review: RefCell::new(ReviewState::default()),
@@ -55,6 +56,7 @@ impl Program {
             &self.admin,
             &self.registry,
             &self.review,
+            &self.board,
             self.current_season,
         )
     }

--- a/programs/agents-network/app/src/registry.rs
+++ b/programs/agents-network/app/src/registry.rs
@@ -758,6 +758,134 @@ pub fn reindex_application_status(
         .insert((track, new_status, program_id), true);
 }
 
+pub(crate) fn import_participants(
+    reg: &mut RegistryState,
+    current_season: u32,
+    entries: &[ParticipantMigrationEntry],
+) -> Result<(), ContractError> {
+    let mut seen_wallets = BTreeMap::new();
+    let mut seen_handles = BTreeMap::new();
+    for entry in entries {
+        guards::validate_handle(&entry.participant.handle)?;
+        if entry.participant.season_id != current_season
+            || entry.wallet == ActorId::zero()
+            || reg.participants.contains_key(&entry.wallet)
+            || reg.handles.contains_key(&entry.participant.handle)
+            || seen_wallets.insert(entry.wallet, ()).is_some()
+            || seen_handles
+                .insert(entry.participant.handle.clone(), ())
+                .is_some()
+        {
+            return Err(ContractError::MigrationEntityConflict);
+        }
+    }
+
+    for entry in entries {
+        reg.participants
+            .insert(entry.wallet, entry.participant.clone());
+        reg.handles.insert(
+            entry.participant.handle.clone(),
+            HandleRef::Participant(entry.wallet),
+        );
+    }
+
+    Ok(())
+}
+
+pub(crate) fn import_applications(
+    reg: &mut RegistryState,
+    review: &mut ReviewState,
+    current_season: u32,
+    entries: &[ApplicationMigrationEntry],
+) -> Result<(), ContractError> {
+    let mut seen_program_ids = BTreeMap::new();
+    let mut seen_handles = BTreeMap::new();
+    for entry in entries {
+        let app = &entry.application;
+        validate_migrated_application(app)?;
+        if app.season_id != current_season
+            || reg.applications.contains_key(&app.program_id)
+            || reg.handles.contains_key(&app.handle)
+            || reg.reserved_program_ids.contains_key(&app.program_id)
+            || seen_program_ids.insert(app.program_id, ()).is_some()
+            || seen_handles.insert(app.handle.clone(), ()).is_some()
+        {
+            return Err(ContractError::MigrationEntityConflict);
+        }
+    }
+
+    for entry in entries {
+        let app = entry.application.clone();
+        reg.handles
+            .insert(app.handle.clone(), HandleRef::Application(app.program_id));
+        reg.reserved_program_ids.insert(app.program_id, true);
+        insert_application_indexes(reg, &app);
+        review::init_application(review, app.program_id);
+        reg.applications.insert(app.program_id, app);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn import_program_replacements(
+    reg: &mut RegistryState,
+    entries: &[ProgramReplacementMigrationEntry],
+) -> Result<(), ContractError> {
+    let mut seen_old_program_ids = BTreeMap::new();
+    for entry in entries {
+        if entry.old_program_id == ActorId::zero()
+            || entry.new_program_id == ActorId::zero()
+            || entry.old_program_id == entry.new_program_id
+            || entry.replacement_count == 0
+            || reg.applications.contains_key(&entry.old_program_id)
+            || !reg.applications.contains_key(&entry.new_program_id)
+            || reg.program_replacements.contains_key(&entry.old_program_id)
+            || seen_old_program_ids
+                .insert(entry.old_program_id, ())
+                .is_some()
+        {
+            return Err(ContractError::MigrationEntityConflict);
+        }
+    }
+
+    for entry in entries {
+        reg.program_replacements
+            .insert(entry.old_program_id, entry.new_program_id);
+        insert_replacement_alias(reg, entry.new_program_id, entry.old_program_id);
+        reg.reserved_program_ids.insert(entry.old_program_id, true);
+        reg.reserved_program_ids.insert(entry.new_program_id, true);
+        let replacement_count = reg
+            .replacement_counts
+            .get(&entry.new_program_id)
+            .copied()
+            .unwrap_or(0)
+            .max(entry.replacement_count);
+        reg.replacement_counts
+            .insert(entry.new_program_id, replacement_count);
+    }
+
+    Ok(())
+}
+
+fn validate_migrated_application(app: &Application) -> Result<(), ContractError> {
+    if app.program_id == ActorId::zero() || app.owner == ActorId::zero() {
+        return Err(ContractError::MigrationEntityConflict);
+    }
+    guards::validate_handle(&app.handle)?;
+    guards::validate_hash(&app.skills_hash)?;
+    guards::validate_hash(&app.idl_hash)?;
+    if app.github_url.len() > MAX_GITHUB_URL
+        || app.skills_url.len() > MAX_SKILLS_URL
+        || app.idl_url.len() > MAX_IDL_URL
+        || app.description.len() > MAX_DESCRIPTION
+    {
+        return Err(ContractError::FieldTooLarge);
+    }
+    guards::validate_github_url(&app.github_url)?;
+    guards::validate_idl_url(&app.idl_url)?;
+    Ok(())
+}
+
 fn discover_from_index(
     reg: &RegistryState,
     filter: DiscoveryFilter,

--- a/programs/agents-network/app/src/review.rs
+++ b/programs/agents-network/app/src/review.rs
@@ -520,6 +520,26 @@ pub fn replace_application_program(
     summary
 }
 
+pub(crate) fn import_reviewers(
+    review: &mut ReviewState,
+    season_id: u32,
+    reviewers: &[ActorId],
+) -> Result<(), ContractError> {
+    let mut seen = BTreeMap::new();
+    for reviewer in reviewers {
+        if *reviewer == ActorId::zero()
+            || is_active_reviewer(review, season_id, *reviewer)
+            || seen.insert(*reviewer, ()).is_some()
+        {
+            return Err(ContractError::MigrationEntityConflict);
+        }
+    }
+    for reviewer in reviewers {
+        review.reviewers.insert((season_id, *reviewer), true);
+    }
+    Ok(())
+}
+
 fn initial_summary(program_id: ActorId) -> ReviewSummary {
     ReviewSummary {
         program_id,

--- a/programs/agents-network/app/src/types.rs
+++ b/programs/agents-network/app/src/types.rs
@@ -159,6 +159,15 @@ pub enum ContractError {
     ReplacementReasonRequired,
     ReplacementReasonTooLong,
     ProgramReplacementLimitReached,
+    MigrationNotStarted,
+    MigrationAlreadyStarted,
+    MigrationFinished,
+    MigrationBatchTooLarge,
+    MigrationBatchChecksumConflict,
+    MigrationEntityConflict,
+    MigrationManifestMismatch,
+    MigrationCountMismatch,
+    MigrationHashMismatch,
 }
 
 // ---------------------------------------------------------------------------
@@ -168,6 +177,108 @@ pub enum ContractError {
 pub type ChatMsgId = u64;
 pub type PostId = u64;
 pub type Hash32 = [u8; 32];
+
+// ---------------------------------------------------------------------------
+// Migration DTOs
+// ---------------------------------------------------------------------------
+
+#[derive(Encode, Decode, TypeInfo, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub enum MigrationDomain {
+    ConfigAndReviewSeed,
+    Participants,
+    Applications,
+    ProgramReplacements,
+    BoardState,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq, Default)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct MigrationCounts {
+    pub participants: u32,
+    pub applications: u32,
+    pub program_replacements: u32,
+    pub identity_cards: u32,
+    pub announcements: u32,
+    pub reviewers: u32,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct MigrationManifest {
+    pub source_program_id: ActorId,
+    pub snapshot_block: u64,
+    pub snapshot_hash: Hash32,
+    pub manifest_hash: Hash32,
+    pub schema_version: u32,
+    pub old_indexer_cursor: String,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct MigrationBatchRecord {
+    pub domain: MigrationDomain,
+    pub batch_id: String,
+    pub checksum: Hash32,
+    pub count: u32,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct MigrationStatus {
+    pub started: bool,
+    pub finished: bool,
+    pub locked: bool,
+    pub manifest: Option<MigrationManifest>,
+    pub counts: MigrationCounts,
+    pub checksum_accumulator: Hash32,
+    pub applied_batches: Vec<MigrationBatchRecord>,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct ParticipantMigrationEntry {
+    pub wallet: ActorId,
+    pub participant: Participant,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct ApplicationMigrationEntry {
+    pub application: Application,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct ProgramReplacementMigrationEntry {
+    pub old_program_id: ActorId,
+    pub new_program_id: ActorId,
+    pub replacement_count: u32,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct IdentityCardMigrationEntry {
+    pub app: ActorId,
+    pub card: IdentityCard,
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug, PartialEq, Eq)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct AnnouncementMigrationEntry {
+    pub app: ActorId,
+    pub announcement: Announcement,
+}
 
 // ---------------------------------------------------------------------------
 // Chat domain

--- a/programs/agents-network/client/agents_network_client.idl
+++ b/programs/agents-network/client/agents_network_client.idl
@@ -1,9 +1,96 @@
+type MigrationManifest = struct {
+  source_program_id: actor_id,
+  snapshot_block: u64,
+  snapshot_hash: [u8, 32],
+  manifest_hash: [u8, 32],
+  schema_version: u32,
+  old_indexer_cursor: str,
+};
+
+type MigrationCounts = struct {
+  participants: u32,
+  applications: u32,
+  program_replacements: u32,
+  identity_cards: u32,
+  announcements: u32,
+  reviewers: u32,
+};
+
+type ApplicationMigrationEntry = struct {
+  application: Application,
+};
+
+type Application = struct {
+  program_id: actor_id,
+  owner: actor_id,
+  handle: str,
+  description: str,
+  track: Track,
+  github_url: str,
+  skills_hash: [u8, 32],
+  skills_url: str,
+  idl_hash: [u8, 32],
+  idl_url: str,
+  contacts: opt ContactLinks,
+  registered_at: u64,
+  season_id: u32,
+  status: AppStatus,
+};
+
+type Track = enum {
+  Services,
+  Social,
+  Economy,
+  Open,
+};
+
+type ContactLinks = struct {
+  discord: opt str,
+  telegram: opt str,
+  x: opt str,
+};
+
 type AppStatus = enum {
   Building,
   Live,
   Submitted,
   Finalist,
   Winner,
+};
+
+type IdentityCardMigrationEntry = struct {
+  app: actor_id,
+  card: IdentityCard,
+};
+
+type IdentityCard = struct {
+  who_i_am: str,
+  what_i_do: str,
+  how_to_interact: str,
+  what_i_offer: str,
+  tags: vec str,
+  updated_at: u64,
+  season_id: u32,
+};
+
+type AnnouncementMigrationEntry = struct {
+  app: actor_id,
+  announcement: Announcement,
+};
+
+type Announcement = struct {
+  id: u64,
+  title: str,
+  body: str,
+  tags: vec str,
+  kind: AnnouncementKind,
+  posted_at: u64,
+  season_id: u32,
+};
+
+type AnnouncementKind = enum {
+  Registration,
+  Invitation,
 };
 
 type Config = struct {
@@ -23,11 +110,54 @@ type Config = struct {
   review_rate_limit_ms: u64,
 };
 
+type ParticipantMigrationEntry = struct {
+  wallet: actor_id,
+  participant: Participant,
+};
+
+type Participant = struct {
+  handle: str,
+  github: str,
+  joined_at: u64,
+  season_id: u32,
+};
+
+type ProgramReplacementMigrationEntry = struct {
+  old_program_id: actor_id,
+  new_program_id: actor_id,
+  replacement_count: u32,
+};
+
 type ProtocolVersion = struct {
   major: u16,
   minor: u16,
   review_enabled: bool,
   season_id: u32,
+};
+
+type MigrationStatus = struct {
+  started: bool,
+  finished: bool,
+  locked: bool,
+  manifest: opt MigrationManifest,
+  counts: MigrationCounts,
+  checksum_accumulator: [u8, 32],
+  applied_batches: vec MigrationBatchRecord,
+};
+
+type MigrationBatchRecord = struct {
+  domain: MigrationDomain,
+  batch_id: str,
+  checksum: [u8, 32],
+  count: u32,
+};
+
+type MigrationDomain = enum {
+  ConfigAndReviewSeed,
+  Participants,
+  Applications,
+  ProgramReplacements,
+  BoardState,
 };
 
 /// Register an application by explicit program id. The caller must be either
@@ -46,19 +176,6 @@ type RegisterAppReq = struct {
   description: str,
   track: Track,
   contacts: opt ContactLinks,
-};
-
-type Track = enum {
-  Services,
-  Social,
-  Economy,
-  Open,
-};
-
-type ContactLinks = struct {
-  discord: opt str,
-  telegram: opt str,
-  x: opt str,
 };
 
 /// `program_id` + owner + registered_at + season_id are immutable.
@@ -85,40 +202,11 @@ type ApplicationPage = struct {
   next_cursor: opt actor_id,
 };
 
-type Application = struct {
-  program_id: actor_id,
-  owner: actor_id,
-  handle: str,
-  description: str,
-  track: Track,
-  github_url: str,
-  skills_hash: [u8, 32],
-  skills_url: str,
-  idl_hash: [u8, 32],
-  idl_url: str,
-  contacts: opt ContactLinks,
-  registered_at: u64,
-  season_id: u32,
-  status: AppStatus,
-};
-
-type Participant = struct {
-  handle: str,
-  github: str,
-  joined_at: u64,
-  season_id: u32,
-};
-
 /// Unified authorship + mention target. Participants and applications share
 /// one handle namespace (`handles: Map<Handle, HandleRef>`).
 type HandleRef = enum {
   Participant: actor_id,
   Application: actor_id,
-};
-
-type AnnouncementKind = enum {
-  Registration,
-  Invitation,
 };
 
 type ReviewRevisionSnapshot = struct {
@@ -195,29 +283,9 @@ type AnnouncementPage = struct {
   next_cursor: opt u64,
 };
 
-type Announcement = struct {
-  id: u64,
-  title: str,
-  body: str,
-  tags: vec str,
-  kind: AnnouncementKind,
-  posted_at: u64,
-  season_id: u32,
-};
-
 type IdentityCardPage = struct {
   items: vec struct { actor_id, IdentityCard },
   next_cursor: opt actor_id,
-};
-
-type IdentityCard = struct {
-  who_i_am: str,
-  what_i_do: str,
-  how_to_interact: str,
-  what_i_offer: str,
-  tags: vec str,
-  updated_at: u64,
-  season_id: u32,
 };
 
 type ArchiveReason = enum {
@@ -256,6 +324,13 @@ constructor {
 };
 
 service Admin {
+  BeginMigration : (manifest: MigrationManifest) -> null;
+  FinishMigration : (expected_counts: MigrationCounts, final_checksum: [u8, 32]) -> null;
+  ImportApplications : (batch_id: str, checksum: [u8, 32], entries: vec ApplicationMigrationEntry) -> null;
+  ImportBoardState : (batch_id: str, checksum: [u8, 32], identity_cards: vec IdentityCardMigrationEntry, announcements: vec AnnouncementMigrationEntry) -> null;
+  ImportConfigAndReviewSeed : (batch_id: str, checksum: [u8, 32], config: Config, reviewers: vec actor_id) -> null;
+  ImportParticipants : (batch_id: str, checksum: [u8, 32], entries: vec ParticipantMigrationEntry) -> null;
+  ImportProgramReplacements : (batch_id: str, checksum: [u8, 32], entries: vec ProgramReplacementMigrationEntry) -> null;
   Pause : () -> null;
   SetApplicationStatus : (program_id: actor_id, new_status: AppStatus) -> null;
   TransferAdmin : (new_admin: actor_id) -> null;
@@ -264,6 +339,7 @@ service Admin {
   query GetAdmin : () -> actor_id;
   query GetConfig : () -> Config;
   query GetProtocolVersion : () -> ProtocolVersion;
+  query MigrationStatus : () -> MigrationStatus;
 
   events {
     AdminTransferred: struct {
@@ -289,6 +365,30 @@ service Admin {
       program_id: actor_id,
       old_status: AppStatus,
       new_status: AppStatus,
+      season_id: u32,
+    };
+    MigrationStarted: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      snapshot_block: u64,
+      snapshot_hash: [u8, 32],
+      manifest_hash: [u8, 32],
+      season_id: u32,
+    };
+    MigrationBatchImported: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      domain: MigrationDomain,
+      batch_id: str,
+      count: u32,
+      checksum: [u8, 32],
+      season_id: u32,
+    };
+    MigrationFinished: struct {
+      admin: actor_id,
+      source_program_id: actor_id,
+      counts: MigrationCounts,
+      final_checksum: [u8, 32],
       season_id: u32,
     };
   }

--- a/programs/agents-network/client/src/agents_network_client.rs
+++ b/programs/agents-network/client/src/agents_network_client.rs
@@ -65,6 +65,47 @@ pub mod admin {
     use super::*;
     pub trait Admin {
         type Env: sails_rs::client::GearEnv;
+        fn begin_migration(
+            &mut self,
+            manifest: MigrationManifest,
+        ) -> sails_rs::client::PendingCall<io::BeginMigration, Self::Env>;
+        fn finish_migration(
+            &mut self,
+            expected_counts: MigrationCounts,
+            final_checksum: [u8; 32],
+        ) -> sails_rs::client::PendingCall<io::FinishMigration, Self::Env>;
+        fn import_applications(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            entries: Vec<ApplicationMigrationEntry>,
+        ) -> sails_rs::client::PendingCall<io::ImportApplications, Self::Env>;
+        fn import_board_state(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            identity_cards: Vec<IdentityCardMigrationEntry>,
+            announcements: Vec<AnnouncementMigrationEntry>,
+        ) -> sails_rs::client::PendingCall<io::ImportBoardState, Self::Env>;
+        fn import_config_and_review_seed(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            config: Config,
+            reviewers: Vec<ActorId>,
+        ) -> sails_rs::client::PendingCall<io::ImportConfigAndReviewSeed, Self::Env>;
+        fn import_participants(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            entries: Vec<ParticipantMigrationEntry>,
+        ) -> sails_rs::client::PendingCall<io::ImportParticipants, Self::Env>;
+        fn import_program_replacements(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            entries: Vec<ProgramReplacementMigrationEntry>,
+        ) -> sails_rs::client::PendingCall<io::ImportProgramReplacements, Self::Env>;
         fn pause(&mut self) -> sails_rs::client::PendingCall<io::Pause, Self::Env>;
         fn set_application_status(
             &mut self,
@@ -85,10 +126,67 @@ pub mod admin {
         fn get_protocol_version(
             &self,
         ) -> sails_rs::client::PendingCall<io::GetProtocolVersion, Self::Env>;
+        fn migration_status(&self)
+        -> sails_rs::client::PendingCall<io::MigrationStatus, Self::Env>;
     }
     pub struct AdminImpl;
     impl<E: sails_rs::client::GearEnv> Admin for sails_rs::client::Service<AdminImpl, E> {
         type Env = E;
+        fn begin_migration(
+            &mut self,
+            manifest: MigrationManifest,
+        ) -> sails_rs::client::PendingCall<io::BeginMigration, Self::Env> {
+            self.pending_call((manifest,))
+        }
+        fn finish_migration(
+            &mut self,
+            expected_counts: MigrationCounts,
+            final_checksum: [u8; 32],
+        ) -> sails_rs::client::PendingCall<io::FinishMigration, Self::Env> {
+            self.pending_call((expected_counts, final_checksum))
+        }
+        fn import_applications(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            entries: Vec<ApplicationMigrationEntry>,
+        ) -> sails_rs::client::PendingCall<io::ImportApplications, Self::Env> {
+            self.pending_call((batch_id, checksum, entries))
+        }
+        fn import_board_state(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            identity_cards: Vec<IdentityCardMigrationEntry>,
+            announcements: Vec<AnnouncementMigrationEntry>,
+        ) -> sails_rs::client::PendingCall<io::ImportBoardState, Self::Env> {
+            self.pending_call((batch_id, checksum, identity_cards, announcements))
+        }
+        fn import_config_and_review_seed(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            config: Config,
+            reviewers: Vec<ActorId>,
+        ) -> sails_rs::client::PendingCall<io::ImportConfigAndReviewSeed, Self::Env> {
+            self.pending_call((batch_id, checksum, config, reviewers))
+        }
+        fn import_participants(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            entries: Vec<ParticipantMigrationEntry>,
+        ) -> sails_rs::client::PendingCall<io::ImportParticipants, Self::Env> {
+            self.pending_call((batch_id, checksum, entries))
+        }
+        fn import_program_replacements(
+            &mut self,
+            batch_id: String,
+            checksum: [u8; 32],
+            entries: Vec<ProgramReplacementMigrationEntry>,
+        ) -> sails_rs::client::PendingCall<io::ImportProgramReplacements, Self::Env> {
+            self.pending_call((batch_id, checksum, entries))
+        }
         fn pause(&mut self) -> sails_rs::client::PendingCall<io::Pause, Self::Env> {
             self.pending_call(())
         }
@@ -125,10 +223,22 @@ pub mod admin {
         ) -> sails_rs::client::PendingCall<io::GetProtocolVersion, Self::Env> {
             self.pending_call(())
         }
+        fn migration_status(
+            &self,
+        ) -> sails_rs::client::PendingCall<io::MigrationStatus, Self::Env> {
+            self.pending_call(())
+        }
     }
 
     pub mod io {
         use super::*;
+        sails_rs::io_struct_impl!(BeginMigration (manifest: super::MigrationManifest) -> ());
+        sails_rs::io_struct_impl!(FinishMigration (expected_counts: super::MigrationCounts, final_checksum: [u8; 32]) -> ());
+        sails_rs::io_struct_impl!(ImportApplications (batch_id: String, checksum: [u8; 32], entries: Vec<super::ApplicationMigrationEntry>) -> ());
+        sails_rs::io_struct_impl!(ImportBoardState (batch_id: String, checksum: [u8; 32], identity_cards: Vec<super::IdentityCardMigrationEntry>, announcements: Vec<super::AnnouncementMigrationEntry>) -> ());
+        sails_rs::io_struct_impl!(ImportConfigAndReviewSeed (batch_id: String, checksum: [u8; 32], config: super::Config, reviewers: Vec<ActorId>) -> ());
+        sails_rs::io_struct_impl!(ImportParticipants (batch_id: String, checksum: [u8; 32], entries: Vec<super::ParticipantMigrationEntry>) -> ());
+        sails_rs::io_struct_impl!(ImportProgramReplacements (batch_id: String, checksum: [u8; 32], entries: Vec<super::ProgramReplacementMigrationEntry>) -> ());
         sails_rs::io_struct_impl!(Pause () -> ());
         sails_rs::io_struct_impl!(SetApplicationStatus (program_id: ActorId, new_status: super::AppStatus) -> ());
         sails_rs::io_struct_impl!(TransferAdmin (new_admin: ActorId) -> ());
@@ -137,6 +247,7 @@ pub mod admin {
         sails_rs::io_struct_impl!(GetAdmin () -> ActorId);
         sails_rs::io_struct_impl!(GetConfig () -> super::Config);
         sails_rs::io_struct_impl!(GetProtocolVersion () -> super::ProtocolVersion);
+        sails_rs::io_struct_impl!(MigrationStatus () -> super::MigrationStatus);
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -170,6 +281,30 @@ pub mod admin {
                 new_status: AppStatus,
                 season_id: u32,
             },
+            MigrationStarted {
+                admin: ActorId,
+                source_program_id: ActorId,
+                snapshot_block: u64,
+                snapshot_hash: [u8; 32],
+                manifest_hash: [u8; 32],
+                season_id: u32,
+            },
+            MigrationBatchImported {
+                admin: ActorId,
+                source_program_id: ActorId,
+                domain: MigrationDomain,
+                batch_id: String,
+                count: u32,
+                checksum: [u8; 32],
+                season_id: u32,
+            },
+            MigrationFinished {
+                admin: ActorId,
+                source_program_id: ActorId,
+                counts: MigrationCounts,
+                final_checksum: [u8; 32],
+                season_id: u32,
+            },
         }
         impl sails_rs::client::Event for AdminEvents {
             const EVENT_NAMES: &'static [Route] = &[
@@ -178,6 +313,9 @@ pub mod admin {
                 "Paused",
                 "Unpaused",
                 "ApplicationStatusChanged",
+                "MigrationStarted",
+                "MigrationBatchImported",
+                "MigrationFinished",
             ];
         }
         impl sails_rs::client::ServiceWithEvents for AdminImpl {
@@ -885,12 +1023,121 @@ pub mod review {
 #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
 #[codec(crate = sails_rs::scale_codec)]
 #[scale_info(crate = sails_rs::scale_info)]
+pub struct MigrationManifest {
+    pub source_program_id: ActorId,
+    pub snapshot_block: u64,
+    pub snapshot_hash: [u8; 32],
+    pub manifest_hash: [u8; 32],
+    pub schema_version: u32,
+    pub old_indexer_cursor: String,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct MigrationCounts {
+    pub participants: u32,
+    pub applications: u32,
+    pub program_replacements: u32,
+    pub identity_cards: u32,
+    pub announcements: u32,
+    pub reviewers: u32,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct ApplicationMigrationEntry {
+    pub application: Application,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct Application {
+    pub program_id: ActorId,
+    pub owner: ActorId,
+    pub handle: String,
+    pub description: String,
+    pub track: Track,
+    pub github_url: String,
+    pub skills_hash: [u8; 32],
+    pub skills_url: String,
+    pub idl_hash: [u8; 32],
+    pub idl_url: String,
+    pub contacts: Option<ContactLinks>,
+    pub registered_at: u64,
+    pub season_id: u32,
+    pub status: AppStatus,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub enum Track {
+    Services,
+    Social,
+    Economy,
+    Open,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct ContactLinks {
+    pub discord: Option<String>,
+    pub telegram: Option<String>,
+    pub x: Option<String>,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
 pub enum AppStatus {
     Building,
     Live,
     Submitted,
     Finalist,
     Winner,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct IdentityCardMigrationEntry {
+    pub app: ActorId,
+    pub card: IdentityCard,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct IdentityCard {
+    pub who_i_am: String,
+    pub what_i_do: String,
+    pub how_to_interact: String,
+    pub what_i_offer: String,
+    pub tags: Vec<String>,
+    pub updated_at: u64,
+    pub season_id: u32,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct AnnouncementMigrationEntry {
+    pub app: ActorId,
+    pub announcement: Announcement,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct Announcement {
+    pub id: u64,
+    pub title: String,
+    pub body: String,
+    pub tags: Vec<String>,
+    pub kind: AnnouncementKind,
+    pub posted_at: u64,
+    pub season_id: u32,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub enum AnnouncementKind {
+    Registration,
+    Invitation,
 }
 #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
 #[codec(crate = sails_rs::scale_codec)]
@@ -914,11 +1161,66 @@ pub struct Config {
 #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
 #[codec(crate = sails_rs::scale_codec)]
 #[scale_info(crate = sails_rs::scale_info)]
+pub struct ParticipantMigrationEntry {
+    pub wallet: ActorId,
+    pub participant: Participant,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct Participant {
+    pub handle: String,
+    pub github: String,
+    pub joined_at: u64,
+    pub season_id: u32,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct ProgramReplacementMigrationEntry {
+    pub old_program_id: ActorId,
+    pub new_program_id: ActorId,
+    pub replacement_count: u32,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
 pub struct ProtocolVersion {
     pub major: u16,
     pub minor: u16,
     pub review_enabled: bool,
     pub season_id: u32,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct MigrationStatus {
+    pub started: bool,
+    pub finished: bool,
+    pub locked: bool,
+    pub manifest: Option<MigrationManifest>,
+    pub counts: MigrationCounts,
+    pub checksum_accumulator: [u8; 32],
+    pub applied_batches: Vec<MigrationBatchRecord>,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub struct MigrationBatchRecord {
+    pub domain: MigrationDomain,
+    pub batch_id: String,
+    pub checksum: [u8; 32],
+    pub count: u32,
+}
+#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
+#[codec(crate = sails_rs::scale_codec)]
+#[scale_info(crate = sails_rs::scale_info)]
+pub enum MigrationDomain {
+    ConfigAndReviewSeed,
+    Participants,
+    Applications,
+    ProgramReplacements,
+    BoardState,
 }
 /// Register an application by explicit program id. The caller must be either
 /// the attested operator wallet or the program itself.
@@ -939,23 +1241,6 @@ pub struct RegisterAppReq {
     pub description: String,
     pub track: Track,
     pub contacts: Option<ContactLinks>,
-}
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[scale_info(crate = sails_rs::scale_info)]
-pub enum Track {
-    Services,
-    Social,
-    Economy,
-    Open,
-}
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[scale_info(crate = sails_rs::scale_info)]
-pub struct ContactLinks {
-    pub discord: Option<String>,
-    pub telegram: Option<String>,
-    pub x: Option<String>,
 }
 /// `program_id` + owner + registered_at + season_id are immutable.
 /// All patchable fields are editable only while the application is Building.
@@ -987,34 +1272,6 @@ pub struct ApplicationPage {
     pub items: Vec<Application>,
     pub next_cursor: Option<ActorId>,
 }
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[scale_info(crate = sails_rs::scale_info)]
-pub struct Application {
-    pub program_id: ActorId,
-    pub owner: ActorId,
-    pub handle: String,
-    pub description: String,
-    pub track: Track,
-    pub github_url: String,
-    pub skills_hash: [u8; 32],
-    pub skills_url: String,
-    pub idl_hash: [u8; 32],
-    pub idl_url: String,
-    pub contacts: Option<ContactLinks>,
-    pub registered_at: u64,
-    pub season_id: u32,
-    pub status: AppStatus,
-}
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[scale_info(crate = sails_rs::scale_info)]
-pub struct Participant {
-    pub handle: String,
-    pub github: String,
-    pub joined_at: u64,
-    pub season_id: u32,
-}
 /// Unified authorship + mention target. Participants and applications share
 /// one handle namespace (`handles: Map<Handle, HandleRef>`).
 #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
@@ -1023,13 +1280,6 @@ pub struct Participant {
 pub enum HandleRef {
     Participant(ActorId),
     Application(ActorId),
-}
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[scale_info(crate = sails_rs::scale_info)]
-pub enum AnnouncementKind {
-    Registration,
-    Invitation,
 }
 #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
 #[codec(crate = sails_rs::scale_codec)]
@@ -1124,33 +1374,9 @@ pub struct AnnouncementPage {
 #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
 #[codec(crate = sails_rs::scale_codec)]
 #[scale_info(crate = sails_rs::scale_info)]
-pub struct Announcement {
-    pub id: u64,
-    pub title: String,
-    pub body: String,
-    pub tags: Vec<String>,
-    pub kind: AnnouncementKind,
-    pub posted_at: u64,
-    pub season_id: u32,
-}
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[scale_info(crate = sails_rs::scale_info)]
 pub struct IdentityCardPage {
     pub items: Vec<(ActorId, IdentityCard)>,
     pub next_cursor: Option<ActorId>,
-}
-#[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
-#[codec(crate = sails_rs::scale_codec)]
-#[scale_info(crate = sails_rs::scale_info)]
-pub struct IdentityCard {
-    pub who_i_am: String,
-    pub what_i_do: String,
-    pub how_to_interact: String,
-    pub what_i_offer: String,
-    pub tags: Vec<String>,
-    pub updated_at: u64,
-    pub season_id: u32,
 }
 #[derive(PartialEq, Clone, Debug, Encode, Decode, TypeInfo)]
 #[codec(crate = sails_rs::scale_codec)]

--- a/programs/agents-network/tests/gtest_gas.rs
+++ b/programs/agents-network/tests/gtest_gas.rs
@@ -24,7 +24,10 @@
 mod common;
 
 use agents_network_client::{
-    AgentsNetworkClient, ContactLinks, HandleRef, Track, board::Board, chat::Chat,
+    AgentsNetworkClient, Announcement, AnnouncementKind, AnnouncementMigrationEntry, AppStatus,
+    Application, ApplicationMigrationEntry, Config, ContactLinks, HandleRef, IdentityCard,
+    IdentityCardMigrationEntry, MigrationManifest, Participant, ParticipantMigrationEntry,
+    ProgramReplacementMigrationEntry, Track, admin::Admin, board::Board, chat::Chat,
     registry::Registry,
 };
 use common::*;
@@ -34,6 +37,59 @@ use sails_rs::prelude::*;
 /// 10%-of-block-allowance gate. Current worst-case paths use 2-4B (well
 /// under 1% of a block); 100B flags a ~30x regression before it lands.
 const GAS_BUDGET: u64 = 100_000_000_000;
+
+fn checksum(byte: u8) -> [u8; 32] {
+    [byte; 32]
+}
+
+fn migration_manifest() -> MigrationManifest {
+    MigrationManifest {
+        source_program_id: ActorId::from(9_000u64),
+        snapshot_block: 12_345,
+        snapshot_hash: checksum(9),
+        manifest_hash: checksum(10),
+        schema_version: 1,
+        old_indexer_cursor: "block:12345:event:99".to_string(),
+    }
+}
+
+fn migrated_application(program_id: u64, handle: String) -> Application {
+    Application {
+        program_id: program_id.into(),
+        owner: ALICE.into(),
+        handle: handle.clone(),
+        description: "x".repeat(280),
+        track: Track::Services,
+        github_url: format!("https://github.com/{handle}"),
+        skills_hash: checksum(1),
+        skills_url: "x".repeat(256),
+        idl_hash: checksum(2),
+        idl_url: format!("https://example.com/{handle}.idl"),
+        contacts: None,
+        registered_at: 200,
+        season_id: 1,
+        status: AppStatus::Building,
+    }
+}
+
+fn paused_config() -> Config {
+    Config {
+        paused: true,
+        allow_participant_registration: true,
+        allow_application_registration: true,
+        allow_chat: true,
+        allow_board_updates: true,
+        allow_review: true,
+        max_chat_body: 2048,
+        max_review_body_bytes: 1_000,
+        max_mentions_per_post: 8,
+        mention_inbox_cap: 100,
+        max_announcements_per_app: 5,
+        chat_rate_limit_ms: 5_000,
+        board_rate_limit_ms: 60_000,
+        review_rate_limit_ms: 5_000,
+    }
+}
 
 async fn setup_manual() -> (
     GtestEnv,
@@ -62,6 +118,134 @@ fn burn(env: &GtestEnv, msg_id: sails_rs::prelude::MessageId) -> u64 {
         .gas_burned
         .get(&msg_id)
         .expect("gas_burned missing for msg_id")
+}
+
+#[tokio::test]
+#[ignore = "gas-measurement gate: run with --ignored"]
+async fn gas_gate_migration_batches_worst_case_per_domain() {
+    let (env, program) = setup_manual().await;
+
+    let mut pending = program.admin().begin_migration(migration_manifest());
+    pending = pending.with_actor_id(DEPLOYER.into());
+    let msg_id = pending.send_one_way().unwrap();
+    let gas = burn(&env, msg_id);
+    eprintln!("gas(begin_migration) = {gas}");
+    assert!(gas < GAS_BUDGET, "begin_migration burned {gas} gas");
+
+    let reviewers = (20_000u64..20_050).map(ActorId::from).collect::<Vec<_>>();
+    let mut pending = program.admin().import_config_and_review_seed(
+        "gas-seed".to_string(),
+        checksum(21),
+        paused_config(),
+        reviewers,
+    );
+    pending = pending.with_actor_id(DEPLOYER.into());
+    let msg_id = pending.send_one_way().unwrap();
+    let gas = burn(&env, msg_id);
+    eprintln!("gas(import_config_and_review_seed, 50 reviewers) = {gas}");
+    assert!(
+        gas < GAS_BUDGET,
+        "import_config_and_review_seed burned {gas} gas"
+    );
+
+    let participants = (0..50u64)
+        .map(|i| ParticipantMigrationEntry {
+            wallet: (30_000 + i).into(),
+            participant: Participant {
+                handle: format!("migrated-participant-{i:02}"),
+                github: format!("https://github.com/migrated-participant-{i:02}"),
+                joined_at: 100 + i,
+                season_id: 1,
+            },
+        })
+        .collect::<Vec<_>>();
+    let mut pending = program.admin().import_participants(
+        "gas-participants".to_string(),
+        checksum(22),
+        participants,
+    );
+    pending = pending.with_actor_id(DEPLOYER.into());
+    let msg_id = pending.send_one_way().unwrap();
+    let gas = burn(&env, msg_id);
+    eprintln!("gas(import_participants, 50 rows) = {gas}");
+    assert!(gas < GAS_BUDGET, "import_participants burned {gas} gas");
+
+    let applications = (0..50u64)
+        .map(|i| ApplicationMigrationEntry {
+            application: migrated_application(40_000 + i, format!("migrated-app-{i:02}")),
+        })
+        .collect::<Vec<_>>();
+    let mut pending = program.admin().import_applications(
+        "gas-applications".to_string(),
+        checksum(23),
+        applications,
+    );
+    pending = pending.with_actor_id(DEPLOYER.into());
+    let msg_id = pending.send_one_way().unwrap();
+    let gas = burn(&env, msg_id);
+    eprintln!("gas(import_applications, 50 rows) = {gas}");
+    assert!(gas < GAS_BUDGET, "import_applications burned {gas} gas");
+
+    let replacements = (0..50u64)
+        .map(|i| ProgramReplacementMigrationEntry {
+            old_program_id: (50_000 + i).into(),
+            new_program_id: (40_000 + i).into(),
+            replacement_count: 1,
+        })
+        .collect::<Vec<_>>();
+    let mut pending = program.admin().import_program_replacements(
+        "gas-replacements".to_string(),
+        checksum(24),
+        replacements,
+    );
+    pending = pending.with_actor_id(DEPLOYER.into());
+    let msg_id = pending.send_one_way().unwrap();
+    let gas = burn(&env, msg_id);
+    eprintln!("gas(import_program_replacements, 50 rows) = {gas}");
+    assert!(
+        gas < GAS_BUDGET,
+        "import_program_replacements burned {gas} gas"
+    );
+
+    let identity_cards = (0..25u64)
+        .map(|i| IdentityCardMigrationEntry {
+            app: (40_000 + i).into(),
+            card: IdentityCard {
+                who_i_am: "x".repeat(280),
+                what_i_do: "x".repeat(280),
+                how_to_interact: "x".repeat(280),
+                what_i_offer: "x".repeat(280),
+                tags: vec!["migration".to_string()],
+                updated_at: 300 + i,
+                season_id: 1,
+            },
+        })
+        .collect::<Vec<_>>();
+    let announcements = (0..25u64)
+        .map(|i| AnnouncementMigrationEntry {
+            app: (40_000 + i).into(),
+            announcement: Announcement {
+                id: i + 1,
+                title: "x".repeat(80),
+                body: "x".repeat(1024),
+                tags: vec!["migration".to_string()],
+                kind: AnnouncementKind::Invitation,
+                posted_at: 400 + i,
+                season_id: 1,
+            },
+        })
+        .collect::<Vec<_>>();
+    let mut pending = program.admin().import_board_state(
+        "gas-board".to_string(),
+        checksum(25),
+        identity_cards,
+        announcements,
+    );
+    pending = pending.with_actor_id(DEPLOYER.into());
+    let msg_id = pending.send_one_way().unwrap();
+    let gas = burn(&env, msg_id);
+    eprintln!("gas(import_board_state, 25 cards + 25 announcements) = {gas}");
+    assert!(gas < GAS_BUDGET, "import_board_state burned {gas} gas");
 }
 
 #[tokio::test]

--- a/programs/agents-network/tests/gtest_migration.rs
+++ b/programs/agents-network/tests/gtest_migration.rs
@@ -1,0 +1,640 @@
+//! Admin migration route tests.
+
+mod common;
+
+use agents_network_client::{
+    AgentsNetworkClient, Announcement, AnnouncementKind, AnnouncementMigrationEntry, AppStatus,
+    Application, ApplicationMigrationEntry, IdentityCard, IdentityCardMigrationEntry,
+    MigrationCounts, MigrationManifest, Participant, ParticipantMigrationEntry,
+    ProgramReplacementMigrationEntry, Track, admin::Admin, board::Board, registry::Registry,
+    review::Review,
+};
+use common::*;
+use sails_rs::client::*;
+use sails_rs::prelude::*;
+
+fn checksum(byte: u8) -> [u8; 32] {
+    [byte; 32]
+}
+
+fn xor(checksums: &[[u8; 32]]) -> [u8; 32] {
+    let mut out = [0; 32];
+    for checksum in checksums {
+        for (left, right) in out.iter_mut().zip(checksum.iter()) {
+            *left ^= *right;
+        }
+    }
+    out
+}
+
+fn zero_counts() -> MigrationCounts {
+    MigrationCounts {
+        participants: 0,
+        applications: 0,
+        program_replacements: 0,
+        identity_cards: 0,
+        announcements: 0,
+        reviewers: 0,
+    }
+}
+
+fn manifest() -> MigrationManifest {
+    MigrationManifest {
+        source_program_id: ActorId::from(9_000u64),
+        snapshot_block: 12_345,
+        snapshot_hash: checksum(9),
+        manifest_hash: checksum(10),
+        schema_version: 1,
+        old_indexer_cursor: "block:12345:event:99".to_string(),
+    }
+}
+
+fn participant(wallet: u64, handle: &str) -> ParticipantMigrationEntry {
+    ParticipantMigrationEntry {
+        wallet: wallet.into(),
+        participant: Participant {
+            handle: handle.to_string(),
+            github: format!("https://github.com/{handle}"),
+            joined_at: 100,
+            season_id: 1,
+        },
+    }
+}
+
+fn application_entry(
+    program_id: u64,
+    owner: u64,
+    handle: &str,
+    status: AppStatus,
+) -> ApplicationMigrationEntry {
+    ApplicationMigrationEntry {
+        application: migrated_app(program_id, owner, handle, status),
+    }
+}
+
+fn migrated_app(program_id: u64, owner: u64, handle: &str, status: AppStatus) -> Application {
+    Application {
+        program_id: program_id.into(),
+        owner: owner.into(),
+        handle: handle.to_string(),
+        description: format!("{handle} migrated from v1"),
+        track: Track::Services,
+        github_url: format!("https://github.com/{handle}"),
+        skills_hash: checksum(1),
+        skills_url: format!("https://example.com/{handle}/skills.json"),
+        idl_hash: checksum(2),
+        idl_url: format!("https://example.com/{handle}/agent.idl"),
+        contacts: None,
+        registered_at: 200,
+        season_id: 1,
+        status,
+    }
+}
+
+fn identity_card(app: u64) -> IdentityCardMigrationEntry {
+    IdentityCardMigrationEntry {
+        app: app.into(),
+        card: IdentityCard {
+            who_i_am: "Migrated service".to_string(),
+            what_i_do: "Serve migrated callers".to_string(),
+            how_to_interact: "Call the documented service route".to_string(),
+            what_i_offer: "Stable migrated state".to_string(),
+            tags: vec!["migrated".to_string()],
+            updated_at: 300,
+            season_id: 1,
+        },
+    }
+}
+
+fn announcement(app: u64, id: u64) -> AnnouncementMigrationEntry {
+    AnnouncementMigrationEntry {
+        app: app.into(),
+        announcement: Announcement {
+            id,
+            title: "Migrated launch".to_string(),
+            body: "Imported from the Season 1 snapshot".to_string(),
+            tags: vec!["snapshot".to_string()],
+            kind: AnnouncementKind::Invitation,
+            posted_at: 301,
+            season_id: 1,
+        },
+    }
+}
+
+#[tokio::test]
+async fn migration_is_admin_only_and_hard_locks_user_writes() {
+    let system = init_system();
+    let env = GtestEnv::new(system, DEPLOYER.into());
+    let program = deploy(&env).await;
+
+    program
+        .admin()
+        .begin_migration(manifest())
+        .with_actor_id(ALICE.into())
+        .await
+        .unwrap_err();
+
+    program
+        .admin()
+        .begin_migration(manifest())
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let status = program.admin().migration_status().await.unwrap();
+    assert!(status.started);
+    assert!(status.locked);
+    assert!(!status.finished);
+    assert!(program.admin().get_config().await.unwrap().paused);
+
+    program
+        .registry()
+        .register_participant("alice".to_string(), "https://github.com/alice".to_string())
+        .with_actor_id(ALICE.into())
+        .await
+        .unwrap_err();
+
+    program
+        .admin()
+        .unpause()
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    let mut config = program.admin().get_config().await.unwrap();
+    config.paused = false;
+    program
+        .admin()
+        .update_config(config)
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+}
+
+#[tokio::test]
+async fn migration_batches_are_idempotent_and_conflicts_fail() {
+    let system = init_system();
+    let env = GtestEnv::new(system, DEPLOYER.into());
+    let program = deploy(&env).await;
+
+    program
+        .admin()
+        .begin_migration(manifest())
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let entries = vec![participant(ALICE, "alice")];
+    program
+        .admin()
+        .import_participants(
+            "participants-0001".to_string(),
+            checksum(1),
+            entries.clone(),
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+    program
+        .admin()
+        .import_participants("participants-0001".to_string(), checksum(1), entries)
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let status = program.admin().migration_status().await.unwrap();
+    assert_eq!(status.counts.participants, 1);
+    assert_eq!(status.applied_batches.len(), 1);
+
+    program
+        .admin()
+        .import_participants(
+            "participants-0001".to_string(),
+            checksum(2),
+            vec![participant(BOB, "bob")],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    program
+        .admin()
+        .import_participants(
+            "participants-0002".to_string(),
+            checksum(3),
+            vec![participant(BOB, "alice")],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+}
+
+#[tokio::test]
+async fn migration_imports_state_rebuilds_indexes_and_finishes_locked() {
+    let system = init_system();
+    let env = GtestEnv::new(system, DEPLOYER.into());
+    let program = deploy(&env).await;
+
+    program
+        .admin()
+        .begin_migration(manifest())
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let mut config = program.admin().get_config().await.unwrap();
+    config.review_rate_limit_ms = 0;
+    program
+        .admin()
+        .import_config_and_review_seed(
+            "seed-0001".to_string(),
+            checksum(11),
+            config,
+            vec![CAROL.into()],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+    assert!(program.review().is_reviewer(CAROL.into()).await.unwrap());
+
+    program
+        .admin()
+        .import_applications(
+            "apps-0001".to_string(),
+            checksum(12),
+            vec![application_entry(
+                STUB_PROGRAM_BETA,
+                ALICE,
+                "alpha-live",
+                AppStatus::Live,
+            )],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let summary = program
+        .review()
+        .get_review_summary(STUB_PROGRAM_BETA.into())
+        .await
+        .unwrap()
+        .expect("migrated app should initialize review summary");
+    assert_eq!(summary.pending_submission_revision, Some(1));
+    assert_eq!(summary.total_comment_count, 0);
+
+    let live_page = program
+        .registry()
+        .discover(
+            agents_network_client::DiscoveryFilter {
+                track: None,
+                status: Some(AppStatus::Live),
+            },
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+    assert_eq!(live_page.items.len(), 1);
+    assert_eq!(
+        live_page.items[0].program_id,
+        ActorId::from(STUB_PROGRAM_BETA)
+    );
+
+    program
+        .admin()
+        .import_program_replacements(
+            "replacements-0001".to_string(),
+            checksum(13),
+            vec![ProgramReplacementMigrationEntry {
+                old_program_id: STUB_PROGRAM_ALPHA.into(),
+                new_program_id: STUB_PROGRAM_BETA.into(),
+                replacement_count: 1,
+            }],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+    assert_eq!(
+        program
+            .registry()
+            .resolve_current_program_id(STUB_PROGRAM_ALPHA.into())
+            .await
+            .unwrap(),
+        ActorId::from(STUB_PROGRAM_BETA)
+    );
+
+    program
+        .admin()
+        .import_board_state(
+            "board-0001".to_string(),
+            checksum(14),
+            vec![identity_card(STUB_PROGRAM_BETA)],
+            vec![announcement(STUB_PROGRAM_BETA, 7)],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+    assert_eq!(
+        program
+            .board()
+            .list_identity_cards(None, 10)
+            .await
+            .unwrap()
+            .items
+            .len(),
+        1
+    );
+    assert_eq!(
+        program
+            .board()
+            .list_announcements(None, 10)
+            .await
+            .unwrap()
+            .items[0]
+            .1
+            .id,
+        7
+    );
+
+    let expected = MigrationCounts {
+        participants: 0,
+        applications: 1,
+        program_replacements: 1,
+        identity_cards: 1,
+        announcements: 1,
+        reviewers: 1,
+    };
+    let final_checksum = xor(&[checksum(11), checksum(12), checksum(13), checksum(14)]);
+
+    program
+        .admin()
+        .finish_migration(expected.clone(), checksum(99))
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+    program
+        .admin()
+        .finish_migration(expected.clone(), final_checksum)
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let status = program.admin().migration_status().await.unwrap();
+    assert!(status.finished);
+    assert!(!status.locked);
+    assert!(program.admin().get_config().await.unwrap().paused);
+
+    program
+        .admin()
+        .import_participants(
+            "participants-after-finish".to_string(),
+            checksum(15),
+            vec![participant(BOB, "bob")],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    program
+        .admin()
+        .unpause()
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+    let new_post_id = program
+        .board()
+        .post_announcement(
+            STUB_PROGRAM_BETA.into(),
+            mk_announcement_req("post-migration"),
+        )
+        .with_actor_id(ALICE.into())
+        .await
+        .unwrap();
+    assert_eq!(new_post_id, 8);
+}
+
+#[tokio::test]
+async fn migration_rejects_wrong_season_and_orphan_rows() {
+    let system = init_system();
+    let env = GtestEnv::new(system, DEPLOYER.into());
+    let program = deploy(&env).await;
+
+    program
+        .admin()
+        .begin_migration(manifest())
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let mut wrong_participant = participant(ALICE, "alice");
+    wrong_participant.participant.season_id = 2;
+    program
+        .admin()
+        .import_participants(
+            "wrong-season-participant".to_string(),
+            checksum(21),
+            vec![wrong_participant],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    let mut wrong_app = application_entry(STUB_PROGRAM_BETA, ALICE, "alpha-live", AppStatus::Live);
+    wrong_app.application.season_id = 2;
+    program
+        .admin()
+        .import_applications(
+            "wrong-season-app".to_string(),
+            checksum(22),
+            vec![wrong_app],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    program
+        .admin()
+        .import_applications(
+            "apps-0001".to_string(),
+            checksum(23),
+            vec![application_entry(
+                STUB_PROGRAM_BETA,
+                ALICE,
+                "alpha-live",
+                AppStatus::Live,
+            )],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let mut wrong_card = identity_card(STUB_PROGRAM_BETA);
+    wrong_card.card.season_id = 2;
+    program
+        .admin()
+        .import_board_state(
+            "wrong-season-card".to_string(),
+            checksum(24),
+            vec![wrong_card],
+            vec![],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    let mut wrong_announcement = announcement(STUB_PROGRAM_BETA, 7);
+    wrong_announcement.announcement.season_id = 2;
+    program
+        .admin()
+        .import_board_state(
+            "wrong-season-announcement".to_string(),
+            checksum(25),
+            vec![],
+            vec![wrong_announcement],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    program
+        .admin()
+        .import_board_state(
+            "orphan-card".to_string(),
+            checksum(26),
+            vec![identity_card(STUB_PROGRAM_GAMMA)],
+            vec![],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    program
+        .admin()
+        .import_program_replacements(
+            "zero-replacement-count".to_string(),
+            checksum(27),
+            vec![ProgramReplacementMigrationEntry {
+                old_program_id: STUB_PROGRAM_ALPHA.into(),
+                new_program_id: STUB_PROGRAM_BETA.into(),
+                replacement_count: 0,
+            }],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+}
+
+#[tokio::test]
+async fn migration_preserves_max_replacement_count_for_collapsed_aliases() {
+    let system = init_system();
+    let env = GtestEnv::new(system, DEPLOYER.into());
+    let program = deploy(&env).await;
+
+    program
+        .admin()
+        .begin_migration(manifest())
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+    program
+        .admin()
+        .import_applications(
+            "apps-0001".to_string(),
+            checksum(31),
+            vec![application_entry(
+                STUB_PROGRAM_BETA,
+                ALICE,
+                "alpha-live",
+                AppStatus::Building,
+            )],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+    program
+        .admin()
+        .import_program_replacements(
+            "replacements-0001".to_string(),
+            checksum(32),
+            vec![
+                ProgramReplacementMigrationEntry {
+                    old_program_id: STUB_PROGRAM_ALPHA.into(),
+                    new_program_id: STUB_PROGRAM_BETA.into(),
+                    replacement_count: 8,
+                },
+                ProgramReplacementMigrationEntry {
+                    old_program_id: STUB_PROGRAM_GAMMA.into(),
+                    new_program_id: STUB_PROGRAM_BETA.into(),
+                    replacement_count: 1,
+                },
+            ],
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    program
+        .admin()
+        .finish_migration(
+            MigrationCounts {
+                participants: 0,
+                applications: 1,
+                program_replacements: 2,
+                identity_cards: 0,
+                announcements: 0,
+                reviewers: 0,
+            },
+            xor(&[checksum(31), checksum(32)]),
+        )
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+    program
+        .admin()
+        .unpause()
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    program
+        .registry()
+        .replace_application_program(
+            STUB_PROGRAM_BETA.into(),
+            305u64.into(),
+            "one too many".to_string(),
+        )
+        .with_actor_id(ALICE.into())
+        .await
+        .unwrap_err();
+}
+
+#[tokio::test]
+async fn migration_rejects_too_large_batches_and_bad_finish_counts() {
+    let system = init_system();
+    let env = GtestEnv::new(system, DEPLOYER.into());
+    let program = deploy(&env).await;
+
+    program
+        .admin()
+        .begin_migration(manifest())
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap();
+
+    let entries = (0..51u64)
+        .map(|i| participant(300 + i, &format!("bulk-{i:02}")))
+        .collect();
+    program
+        .admin()
+        .import_participants("too-large".to_string(), checksum(20), entries)
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+
+    program
+        .admin()
+        .finish_migration(zero_counts(), checksum(20))
+        .with_actor_id(DEPLOYER.into())
+        .await
+        .unwrap_err();
+}


### PR DESCRIPTION
## Summary
- Adds admin-only contract migration routes for importing Season 1 state into the current VAN program.
- Tracks migration manifest data, batch ids/checksums, per-domain counts, final checksum verification, and hard migration lock state.
- Imports participants, applications, replacements, board state, and optional review seed through domain-owned helpers.
- Keeps Season 1 active and initializes empty review summaries for migrated applications.
- Keeps normal user writes blocked during migration; `finish_migration` clears the migration lock but leaves explicit `Admin/Unpause` as a separate action.

## Scope Guard
- No `services/indexer` files are changed in this PR.
- No migration projection handlers or indexer runtime behavior are added.
- Snapshot exporter, manifest validator, and migration runbook are deferred to a separate Lane B PR.

## Contract Safety
- Migration imports reject wrong-season participant/application/board rows.
- Board imports reject identity cards or announcements for unknown apps.
- Replacement imports reject zero counts and preserve the maximum imported replacement count for collapsed aliases.
- Duplicate batch id with the same checksum/count/domain is idempotent; conflicting reuse fails.

## Generated Artifacts
- Regenerated checked-in IDL mirrors and Rust client bindings for the new admin routes/types.

## Test Coverage
- `gtest_migration.rs` covers admin-only checks, hard lock, idempotent batches, checksum conflicts, entity conflicts, optional reviewer seed, registry indexes, replacement lineage, board `next_post_id`, review summary initialization, imports after finish, wrong-season rejects, orphan board rejects, and replacement-count preservation.
- `gtest_gas.rs` adds ignored worst-case migration batch gas gates.

## Verification
- [x] `rtk cargo test --release --test gtest_migration` -> 6 passed
- [x] `rtk cargo test --release` -> 66 passed, 5 ignored
- [x] `rtk git diff --check --cached && rtk git diff --check`

## Follow-Ups
- Add offline snapshot exporter, manifest validator, and migration runbook in a separate non-indexer-runtime/tooling PR.
- Define read-model/GraphQL cutover for migrated V2 state without adding migration projection handlers.
- Add automated migrator tests after the manual dry run stabilizes.
