### PR TITLE
Guard frontend against retired program ID

### DIFF
--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -1,9 +1,20 @@
 const DEFAULT_VARA_NETWORK = 'mainnet'
 const DEFAULT_VARA_RPC_URL = 'wss://rpc.vara.network'
 const DEFAULT_VARA_AGENTS_PROGRAM_ID = '0x99a8f878745e785ee6af4a59a8f1912e67e19259a35c71e6bf55861a1348251e'
+const RETIRED_VARA_AGENTS_PROGRAM_IDS = new Set([
+  '0x19f27f4c906a5ac230be82d907850d44c7a7fff1b4c6903f62e78e09e0b353f3',
+])
 
 function nonEmpty(value: string | undefined, fallback: string) {
   return value?.trim() || fallback
+}
+
+function activeProgramId(value: string | undefined) {
+  const candidate = nonEmpty(value, DEFAULT_VARA_AGENTS_PROGRAM_ID)
+
+  return RETIRED_VARA_AGENTS_PROGRAM_IDS.has(candidate.toLowerCase())
+    ? DEFAULT_VARA_AGENTS_PROGRAM_ID
+    : candidate
 }
 
 const varaNetwork = nonEmpty(process.env.NEXT_PUBLIC_VARA_NETWORK, DEFAULT_VARA_NETWORK)
@@ -22,7 +33,7 @@ export const env = {
     nonEmpty(process.env.NEXT_PUBLIC_VARA_ARCHIVE_URL, 'https://v2.archive.subsquid.io/network/vara'),
   indexerGraphqlUrl:
     nonEmpty(process.env.NEXT_PUBLIC_INDEXER_GRAPHQL_URL, '/api/agents/graphql'),
-  programId: nonEmpty(process.env.NEXT_PUBLIC_VARA_AGENTS_PROGRAM_ID, DEFAULT_VARA_AGENTS_PROGRAM_ID),
+  programId: activeProgramId(process.env.NEXT_PUBLIC_VARA_AGENTS_PROGRAM_ID),
 } as const
 
 export function getMissingClientEnv() {


### PR DESCRIPTION
## Summary
- Treat the retired v1 program ID as invalid in frontend env resolution
- Fall back to the v2 mainnet program ID when stale deploy-time config still injects the retired ID

## Verification
- npm test
- npm run typecheck
- NEXT_PUBLIC_VARA_AGENTS_PROGRAM_ID=0x19f27f4c906a5ac230be82d907850d44c7a7fff1b4c6903f62e78e09e0b353f3 npm run build

Note: npm run lint is not runnable in the current package because eslint is not installed.