### PR TITLE
Recover indexer v2 program cutover

### DIFF
--- a/services/indexer/src/config.ts
+++ b/services/indexer/src/config.ts
@@ -7,6 +7,29 @@
 // working during the rename window.
 import "dotenv/config";
 
+export const DEFAULT_VARA_AGENTS_PROGRAM_ID =
+  "0x99a8f878745e785ee6af4a59a8f1912e67e19259a35c71e6bf55861a1348251e";
+export const V2_CUTOVER_REPLAY_CURSOR_BLOCK = 33754148;
+
+const RETIRED_VARA_AGENTS_PROGRAM_IDS = new Set([
+  "0x19f27f4c906a5ac230be82d907850d44c7a7fff1b4c6903f62e78e09e0b353f3",
+]);
+
+export function activeVaraAgentsProgramId(value: string): string;
+export function activeVaraAgentsProgramId(value: undefined): undefined;
+export function activeVaraAgentsProgramId(value: string | undefined): string | undefined;
+export function activeVaraAgentsProgramId(value: string | undefined): string | undefined {
+  const candidate = value?.trim();
+  if (!candidate) return candidate;
+  return RETIRED_VARA_AGENTS_PROGRAM_IDS.has(candidate.toLowerCase())
+    ? DEFAULT_VARA_AGENTS_PROGRAM_ID
+    : candidate;
+}
+
+export function shouldReplayV2Cutover(programId: string | undefined): boolean {
+  return programId?.trim().toLowerCase() === DEFAULT_VARA_AGENTS_PROGRAM_ID;
+}
+
 function required(key: string, fallbackKey?: string): string {
   const v = process.env[key] ?? (fallbackKey ? process.env[fallbackKey] : undefined);
   if (!v) throw new Error(`missing required env: ${key}`);
@@ -33,7 +56,7 @@ function optionalInt(key: string, fallback: number, fallbackKey?: string): numbe
 }
 
 export const config = {
-  programId: optionalNonEmpty("VARA_AGENTS_PROGRAM_ID", "HACKATHON_PROGRAM_ID"),
+  programId: activeVaraAgentsProgramId(optionalNonEmpty("VARA_AGENTS_PROGRAM_ID", "HACKATHON_PROGRAM_ID")),
   idlPath: optionalNonEmpty("VARA_AGENTS_IDL_PATH", "HACKATHON_IDL_PATH"),
   startBlock: optionalInt("VARA_AGENTS_START_BLOCK", 0, "HACKATHON_START_BLOCK"),
   seasonId: optionalInt("VARA_AGENTS_SEASON_ID", 1, "HACKATHON_SEASON_ID"),
@@ -55,9 +78,16 @@ export const config = {
 export type Config = typeof config;
 
 export function requireProcessorConfig() {
+  const programId = activeVaraAgentsProgramId(
+    required("VARA_AGENTS_PROGRAM_ID", "HACKATHON_PROGRAM_ID"),
+  );
+
   return {
     ...config,
-    programId: required("VARA_AGENTS_PROGRAM_ID", "HACKATHON_PROGRAM_ID"),
+    programId,
+    v2CutoverReplayCursorBlock: shouldReplayV2Cutover(programId)
+      ? V2_CUTOVER_REPLAY_CURSOR_BLOCK
+      : null,
     idlPath: required("VARA_AGENTS_IDL_PATH", "HACKATHON_IDL_PATH"),
     varaRpcUrl: required("VARA_RPC_URL"),
   } as const;

--- a/services/indexer/src/processor.ts
+++ b/services/indexer/src/processor.ts
@@ -26,6 +26,10 @@ export interface ProcessorHooks {
   onBlock: (ctx: BlockContext) => Promise<void>;
 }
 
+export function v2CutoverReplayMarkerKey(programId: string, cursorBlock: number): string {
+  return `processor:v2-cutover-replay:${programId.toLowerCase()}:${cursorBlock}`;
+}
+
 export async function createProcessor(hooks: ProcessorHooks) {
   const config = requireProcessorConfig();
   const backfillFetchConcurrency = Math.max(1, config.processorBackfillFetchConcurrency);
@@ -214,6 +218,46 @@ export async function createProcessor(hooks: ProcessorHooks) {
     return config.startBlock;
   }
 
+  async function ensureV2CutoverReplayCursor(): Promise<void> {
+    const replayCursorBlock = config.v2CutoverReplayCursorBlock;
+    if (replayCursorBlock == null) return;
+
+    const markerKey = v2CutoverReplayMarkerKey(config.programId, replayCursorBlock);
+    const now = BigInt(Date.now());
+
+    await db.transaction(async (tx) => {
+      const marker = await tx
+        .select()
+        .from(schema.eventProcessed)
+        .where(eq(schema.eventProcessed.key, markerKey))
+        .limit(1);
+      if (marker[0]) return;
+
+      const cursor = await tx
+        .select()
+        .from(schema.processorCursor)
+        .where(eq(schema.processorCursor.id, "main"))
+        .limit(1);
+
+      if (cursor[0] && cursor[0].lastProcessedBlock > replayCursorBlock) {
+        await tx
+          .update(schema.processorCursor)
+          .set({ lastProcessedBlock: replayCursorBlock, updatedAt: now })
+          .where(eq(schema.processorCursor.id, "main"));
+        log.warn("rewound processor cursor for v2 cutover replay", {
+          from: cursor[0].lastProcessedBlock,
+          to: replayCursorBlock,
+          programId: config.programId,
+        });
+      }
+
+      await tx
+        .insert(schema.eventProcessed)
+        .values({ key: markerKey, processedAt: now })
+        .onConflictDoNothing({ target: schema.eventProcessed.key });
+    });
+  }
+
   /** Most public Vara RPCs run with pruning — state reads older than ~256
    *  blocks fail with "State already discarded". Production should use an
    *  archive endpoint and replay every missing block. Local/dev pruned RPCs
@@ -236,6 +280,7 @@ export async function createProcessor(hooks: ProcessorHooks) {
   }
 
   async function runBackfill(toBlock: number): Promise<void> {
+    await ensureV2CutoverReplayCursor();
     let from = await clampedResumePoint(toBlock);
     if (from > toBlock) return;
     log.info("backfill start", { from, to: toBlock, fetchConcurrency: backfillFetchConcurrency });

--- a/services/indexer/test/config.test.ts
+++ b/services/indexer/test/config.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.DATABASE_URL ??= "postgres://indexer:indexer@localhost:5433/indexer";
+
+const {
+  DEFAULT_VARA_AGENTS_PROGRAM_ID,
+  V2_CUTOVER_REPLAY_CURSOR_BLOCK,
+  activeVaraAgentsProgramId,
+  shouldReplayV2Cutover,
+} = await import("../src/config.js");
+
+test("retired program id resolves to the v2 mainnet program", () => {
+  assert.equal(
+    activeVaraAgentsProgramId(
+      "0x19f27f4c906a5ac230be82d907850d44c7a7fff1b4c6903f62e78e09e0b353f3",
+    ),
+    DEFAULT_VARA_AGENTS_PROGRAM_ID,
+  );
+});
+
+test("v2 program schedules the cutover replay", () => {
+  assert.equal(shouldReplayV2Cutover(DEFAULT_VARA_AGENTS_PROGRAM_ID), true);
+  assert.equal(V2_CUTOVER_REPLAY_CURSOR_BLOCK, 33754148);
+});
+


### PR DESCRIPTION
## Summary
- Treat the retired network program ID as the v2 mainnet program in indexer config
- Rewind the processor cursor once for the v2 cutover replay window so missed registrations are ingested
- Add config coverage for the retired-program fallback and replay block

## Verification
- npm test
- npm run typecheck
- npm run build

## Rollout
Deploy indexer/processor after merge. The first fixed boot rewinds `processor_cursor.main` from the stale height to block `33754148` once, then normal backfill processes from `33754149`.