### PR TITLE
Fix indexer migration seed table name

### DIFF
--- a/services/indexer/drizzle/0014_seed_coach_migrated_read_model.sql
+++ b/services/indexer/drizzle/0014_seed_coach_migrated_read_model.sql
@@ -5,7 +5,7 @@ BEGIN;
 -- Remove stale state projections from the retired program. Chat/interactions stay append-only.
 DELETE FROM "project_review_approvals";
 DELETE FROM "project_review_comments";
-DELETE FROM "project_review_guidances";
+DELETE FROM "project_review_guidance";
 DELETE FROM "project_review_links";
 DELETE FROM "project_review_summaries";
 DELETE FROM "review_comments";
@@ -788,4 +788,3 @@ BEGIN
 END $$;
 
 COMMIT;
-

--- a/services/indexer/test/migration-seed.test.ts
+++ b/services/indexer/test/migration-seed.test.ts
@@ -17,4 +17,6 @@ test("coach migration read-model seed is journaled with expected counts", () => 
   assert.match(seedSql, /c_reviewers <> 0/);
   assert.match(seedSql, /c_coaches <> 1/);
   assert.match(seedSql, /processor_cursor/);
+  assert.match(seedSql, /DELETE FROM "project_review_guidance"/);
+  assert.doesNotMatch(seedSql, /project_review_guidances/);
 });


### PR DESCRIPTION
## Summary
- fix the coach migration seed to delete the existing `project_review_guidance` table
- add a guard test so the pluralized typo cannot return

## Verification
- `cd services/indexer && DATABASE_URL=postgres://indexer:indexer@localhost:5433/indexer npm test`
- `cd services/indexer && DATABASE_URL=postgres://indexer:indexer@localhost:5433/indexer npm run typecheck`
- `cd services/indexer && DATABASE_URL=postgres://indexer:indexer@localhost:5433/indexer npm run build`
- `git diff --check`

## Deploy note
The previous prod redeploy synced manifests but the indexer deployment degraded. The failed migration referenced `project_review_guidances`, which does not exist; the correct table from migration 0012 and schema is `project_review_guidance`. Because the seed runs inside a transaction, prod should not have recorded migration 0014.