### PR TITLE
[codex] frontend: bypass stale IDL cache

### DIFF
--- a/frontend/lib/vara-program.ts
+++ b/frontend/lib/vara-program.ts
@@ -78,7 +78,7 @@ export function isGithubUrl(value: string) {
 
 async function loadIdl() {
   if (!idlPromise) {
-    idlPromise = fetch(IDL_PATH, { cache: 'force-cache' }).then(async (res) => {
+    idlPromise = fetch(IDL_PATH, { cache: 'no-store' }).then(async (res) => {
       if (!res.ok) throw new Error(`Failed to load IDL from ${IDL_PATH}`)
       return res.text()
     })

--- a/frontend/test/project-review-ui.test.mjs
+++ b/frontend/test/project-review-ui.test.mjs
@@ -7,6 +7,7 @@ const queuePage = readFileSync(new URL('../app/dashboard/project-reviews/page.ts
 const chatPage = readFileSync(new URL('../app/chat/page.tsx', import.meta.url), 'utf8')
 const submitForm = readFileSync(new URL('../components/project-review-submit-form.tsx', import.meta.url), 'utf8')
 const indexerClient = readFileSync(new URL('../lib/indexer-client.ts', import.meta.url), 'utf8')
+const varaProgram = readFileSync(new URL('../lib/vara-program.ts', import.meta.url), 'utf8')
 
 test('project review UI covers public guidance outcomes', () => {
   for (const outcome of ['Proceed', 'NeedsChanges', 'NotRecommended']) {
@@ -34,4 +35,9 @@ test('project review submit form preserves approval-disabled fallback', () => {
   assert.match(submitForm, /getProgramConfig\(account\.address\)/)
   assert.match(submitForm, /config\.require_project_review_approval/)
   assert.match(submitForm, /submitProjectReview\(account, githubUrl, idea\)/)
+})
+
+test('Sails IDL fetch bypasses stale browser cache', () => {
+  assert.match(varaProgram, /fetch\(IDL_PATH, \{ cache: 'no-store' \}\)/)
+  assert.doesNotMatch(varaProgram, /force-cache/)
 })


### PR DESCRIPTION
## Summary
- fetch the Sails IDL with `cache: no-store` so browser cache cannot keep an older contract shape after deploy
- add a regression assertion covering the IDL fetch cache mode

## Root cause
The prod review page can load new JS that calls `Review/ListCoaches` while the browser still serves an older cached `/idl/agents_network_client.idl`, leaving `ListCoaches` undefined in `sails.services.Review.queries`.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`
- local production server: `npm start -- --hostname 127.0.0.1 --port 3010`
- verified local `/dashboard/reviews` returns HTTP 200
- verified local `/idl/agents_network_client.idl` contains `ListCoaches`
- verified served client chunk contains `cache:"no-store"` and no app static chunk contains `force-cache`
- `git diff --check`