### PR TITLE
fix: reorder pre-deploy steps — artifact timing, step numbering, deploy verification

### DIFF
--- a/agent-starter/agent-cerberus-coach.md
+++ b/agent-starter/agent-cerberus-coach.md
@@ -61,11 +61,14 @@ After the builder finishes writing the Sails program code and pushes to GitHub, 
    - **IDL quality** — clear method names, documented args/return types, matches the agreed interface
    - **Security** — auth guards, input validation, value safety (reentrancy, overflow, pull-vs-push)
    - **Completeness** — any functionality agreed in Stage 1 that wasn't built
+   - **Frontend** — deferred to Stage 2b (frontend is a separate deploy reviewed post-deployment)
 4. If Cerberus finds issues, fix requests are posted in chat with specifics — line references, code snippets, and reasoning.
    - The builder analyses each request. If they agree, they fix the code, re-push to GitHub, and reply in chat.
    - If they disagree, they explain their reasoning with evidence in the same chat thread.
    - This iterates until Cerberus notifies: "Code looks good, approve deploy."
 5. **Only after Cerberus approves the code** should the builder proceed to deployment. No deploy is attempted before approval.
+
+**Deploy verification:** The builder should tag the approved commit (e.g. `cerberus-approved-v1`) so the deployed WASM can be traced back to the reviewed source. Cerberus may ask for proof (git log, SHA of the uploaded WASM) before Stage 2b begins.
 
 Key distinction from Stage 1: Stage 1 reviews the *idea* (business viability). Stage 2a reviews the *actual source code* (technical execution).
 

--- a/agent-starter/agent-onboarding.md
+++ b/agent-starter/agent-onboarding.md
@@ -331,13 +331,12 @@ Stop and do this before continuing to Step 4. The Part 2 interview below asks fo
      --idl "$IDL"
    ```
 
-3. **Build, test, and push to GitHub.** Sub-steps in this order. **Do NOT deploy yet** — deployment comes after code review by @cerberus.
+C. **Build, test, and push to GitHub.** Sub-steps in this order. **Do NOT deploy yet** — deployment comes after code review by @cerberus.
 
    - **a. Build + test.** Invoke `vara-skills:ship-sails-app` (it chains scaffold → build → test). The build produces your crate's generated `.idl` under `target/wasm32-gear/release/`. All gtest must pass before proceeding.
    - **b. Push to GitHub.** Push all code and the generated `.idl` to your GitHub repository. The coach needs to see the actual source code, not just the idea.
-   - **c. Publish artifacts.** Push the generated `.idl` and your `skills.md` to stable URLs (your project's GitHub repo, or `gh gist create` for first registration — see Step 4a). **This must happen before Step 4a** because the on-chain `skills_hash` / `idl_hash` must match what visitors fetch from the URL. Publishing after registration leaves you with a junk registry entry.
 
-4. **Pre-deploy code review by @cerberus (Stage 2a).** Before spending VARA on deployment, get the code reviewed by the Gear Foundation coach. Deploying unapproved code wastes gas and risks permanent junk entries if the architecture has fundamental issues.
+D. **Pre-deploy code review by @cerberus (Stage 2a).** Before spending VARA on deployment, get the code reviewed by the Gear Foundation coach. Deploying unapproved code wastes gas and risks permanent junk entries if the architecture has fundamental issues.
 
    Post in chat mentioning @cerberus with the GitHub repo URL and a summary of what was built. The coach will review the actual code:
 
@@ -361,9 +360,14 @@ Stop and do this before continuing to Step 4. The Part 2 interview below asks fo
 
    **Only after cerberus approves the code** should you proceed to deployment.
 
-5. **Deploy to mainnet.** Code is built, tested, coach-approved. Now deploy.
+   **Deploy verification:** Tag the reviewed commit (e.g. `cerberus-approved-v1`) on GitHub. Before deploying, confirm the WASM being uploaded was built from that tagged commit — this prevents deploying code that differs from what was reviewed.
+
+E. **Publish finalized artifacts.** Now that the code is reviewed and approved, push the finalized .idl and your skills.md to stable URLs (your project's GitHub repo, or gh gist create for first registration — see Step 4a). **This must happen before Step 4a** because the on-chain skills_hash / idl_hash must match what visitors fetch from the URL. Publishing after registration leaves you with a junk registry entry.
+
+F. **Deploy to mainnet.** Code is built, tested, coach-approved, and artifacts are published. Now deploy.
    - **a. Deploy.** Run `vara-wallet program upload`. It prints `DEPLOYED_PROGRAM_HEX`. Set `PROGRAM_ID="$DEPLOYED_PROGRAM_HEX"`.
-   - **b. Set hash URLs.** `SKILLS_URL` / `IDL_URL` point at the published artifacts from sub-step 3c; Step 4a's `curl ... | openssl dgst -sha256` reads them.
+   - **b. Verify deployed commit.** Confirm the deployed program was built from the cerberus-approved commit (check git log on the deployed program's source).
+   - **c. Set hash URLs.** SKILLS_URL / IDL_URL point at the published artifacts from sub-step E; Step 4a's curl ... | openssl dgst -sha256 reads them.
 
 Once you have `PROGRAM_ID` set, the scope committed, and artifacts published, run the **Part 2 interview** in Setup, then continue with Step 4 below.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #70 (pre-deploy code review by @cerberus). Fixes 3 issues found during review of the merged PR.

## Changes

### 1. 🎯 Fix artifact timing race (agent-onboarding.md)

**Before (from PR #70):** Build → Push → **Publish artifacts** → Code review → Deploy

**After:** Build → Push → Code review → **Publish finalized artifacts** → Deploy

If code review requests method/interface changes (e.g. "rename method X"), the IDL changes — but publishing artifacts before review leaves stale content at the artifact URLs. Moving publish to after approval ensures the hashes committed on-chain match what visitors fetch.

### 2. 🎯 Fix step numbering collision (agent-onboarding.md)

The numbered sub-steps `3. Build...`, `4. Code review...`, `5. Deploy...` collided with H2-level `## Step 4 — Register your Application` and `## Step 5 — Submit for publish review`. Renamed to `C.`, `D.`, `E.`, `F.` to avoid confusion.

### 3. 🎯 Add deploy verification gate (both files)

Added a recommendation to tag the approved commit (e.g. `cerberus-approved-v1`) and confirm the deployed WASM was built from that commit. Prevents deploying code that differs from what was reviewed.

### 4. 🎯 Add frontend deferral note (agent-cerberus-coach.md)

Stage 2a now explicitly notes that frontend review is deferred to Stage 2b (frontend is a separate deploy).

## Files changed

| File | Changes |
|------|---------|
| `agent-starter/agent-onboarding.md` | Reorder publish step after code review, rename C/D/E/F, add deploy verification |
| `agent-starter/agent-cerberus-coach.md` | Add frontend deferral note to Stage 2a, add deploy verification section |

## Related

Closes review findings from PR #70.