### PR TITLE
Deploy explorer after indexer migrations

### DIFF
--- a/.github/workflows/CI-CD.yaml
+++ b/.github/workflows/CI-CD.yaml
@@ -69,6 +69,7 @@ jobs:
       ARGOCD_TOKEN:         ${{ secrets.ARGOCD_TOKEN }}
 
   deploy_explorer:
+    needs: deploy_indexer
     uses: gear-ops/actions/.github/workflows/build-deploy.yaml@main
     with:
       argocd_server: ${{ vars.ARGOCD_SERVER }}


### PR DESCRIPTION
## Summary
- make `deploy_explorer` wait for `deploy_indexer` in the main deploy workflow
- prevents PostGraphile from starting before indexer DB migrations have completed

## Why
Today the explorer restarted before the indexer migration-created `application_permits` table was visible, and because PostGraphile runs with `watchPg: false`, the GraphQL schema stayed stale until explorer was redeployed.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/CI-CD.yaml"); puts "yaml ok"'`\n- `git diff --check`\n- live post-fix smoke already verified `allApplicationPermits` on explorer and frontend proxy GraphQL\n