### PR TITLE
Fix project review summary collision data

### DIFF
--- a/services/indexer/drizzle/0016_repair_project_review_summary_collision.sql
+++ b/services/indexer/drizzle/0016_repair_project_review_summary_collision.sql
@@ -1,0 +1,50 @@
+-- Repair the production project_review_id=1 projection after the migrated
+-- ProofPack row masked the live MoodMosaic submission before the upsert fix.
+INSERT INTO "project_review_summaries" (
+  "project_review_id",
+  "owner",
+  "github_url",
+  "idea",
+  "status",
+  "linked_program_id",
+  "comment_count",
+  "latest_guidance_outcome",
+  "latest_guidance",
+  "latest_reviewer",
+  "season_id",
+  "created_at",
+  "updated_at",
+  "hidden",
+  "tombstoned"
+) VALUES (
+  '1',
+  '0x5e77a4b294a4a1b4fa6899b08933bd7a265a64ed3035c98a849a238cc5c24844',
+  'https://github.com/MedovTimur/agent-experiments/tree/main/cerberus-approval-ladder/00-moodmosaic',
+  'MoodMosaic is a Social-track prototype for daily mood boards from journal entries. Users provide short notes; the service returns mood summary, palette, and image prompt. Current artifact intentionally has no Sails program yet; review goal is Stage 1 feedback on whether to evolve it into an agent-consumable Vara service such as JournalEntry(entry_hash,mood_tags) and GetMoodSummary(agent_id,since).',
+  'Submitted',
+  NULL,
+  0,
+  NULL,
+  NULL,
+  NULL,
+  1,
+  1782394428000,
+  1782394428000,
+  false,
+  false
+)
+ON CONFLICT ("project_review_id") DO UPDATE SET
+  "owner" = EXCLUDED."owner",
+  "github_url" = EXCLUDED."github_url",
+  "idea" = EXCLUDED."idea",
+  "status" = EXCLUDED."status",
+  "linked_program_id" = EXCLUDED."linked_program_id",
+  "comment_count" = EXCLUDED."comment_count",
+  "latest_guidance_outcome" = EXCLUDED."latest_guidance_outcome",
+  "latest_guidance" = EXCLUDED."latest_guidance",
+  "latest_reviewer" = EXCLUDED."latest_reviewer",
+  "season_id" = EXCLUDED."season_id",
+  "created_at" = EXCLUDED."created_at",
+  "updated_at" = EXCLUDED."updated_at",
+  "hidden" = EXCLUDED."hidden",
+  "tombstoned" = EXCLUDED."tombstoned";

--- a/services/indexer/drizzle/meta/_journal.json
+++ b/services/indexer/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1782317600000,
       "tag": "0015_application_permits",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1782474000000,
+      "tag": "0016_repair_project_review_summary_collision",
+      "breakpoints": true
     }
   ]
 }

--- a/services/indexer/test/migration-seed.test.ts
+++ b/services/indexer/test/migration-seed.test.ts
@@ -10,6 +10,10 @@ const applicationPermitsSql = readFileSync(
   new URL("../drizzle/0015_application_permits.sql", import.meta.url),
   "utf8",
 );
+const projectReviewRepairSql = readFileSync(
+  new URL("../drizzle/0016_repair_project_review_summary_collision.sql", import.meta.url),
+  "utf8",
+);
 const journal = readFileSync(new URL("../drizzle/meta/_journal.json", import.meta.url), "utf8");
 
 test("coach migration read-model seed is journaled with expected counts", () => {
@@ -32,4 +36,11 @@ test("application permits projection table is journaled", () => {
   assert.match(applicationPermitsSql, /"details_hash" text NOT NULL/);
   assert.match(applicationPermitsSql, /application_permits_approval_event_unique/);
   assert.match(applicationPermitsSql, /application_permits_consume_event_unique/);
+});
+
+test("project review summary collision repair is journaled", () => {
+  assert.match(journal, /0016_repair_project_review_summary_collision/);
+  assert.match(projectReviewRepairSql, /project_review_id"/);
+  assert.match(projectReviewRepairSql, /00-moodmosaic/);
+  assert.match(projectReviewRepairSql, /ON CONFLICT \("project_review_id"\) DO UPDATE/);
 });


### PR DESCRIPTION
## Summary
- add an idempotent migration repairing project_review_id=1 to the live MoodMosaic contract state
- journal the migration and cover it with the existing migration test

## Evidence
- `vara-wallet --network mainnet --seed //Alice call ... Review/GetProjectReviewSummary --args [1]` returned MoodMosaic owner/github/status/updated_at from the live contract
- public GraphQL still showed the stale ProofPack row after the indexer code deploy, so this repair applies the missing projection state

## Validation
- `DATABASE_URL=postgres://indexer:indexer@localhost:5433/indexer npm test`
- `npm run typecheck`