### PR TITLE
fix(indexer): overwrite stale project review data from old PID on conflict

### DIFF
--- a/services/indexer/src/handlers/review.ts
+++ b/services/indexer/src/handlers/review.ts
@@ -664,7 +664,25 @@ export async function handleProjectReviewSubmitted(
   await db
     .insert(schema.projectReviewSummaries)
     .values(values)
-    .onConflictDoNothing({ target: schema.projectReviewSummaries.projectReviewId });
+    .onConflictDoUpdate({
+      target: schema.projectReviewSummaries.projectReviewId,
+      set: {
+        owner: sql`excluded.owner`,
+        githubUrl: sql`excluded.github_url`,
+        idea: sql`excluded.idea`,
+        status: sql`excluded.status`,
+        linkedProgramId: sql`excluded.linked_program_id`,
+        commentCount: sql`excluded.comment_count`,
+        latestGuidanceOutcome: sql`excluded.latest_guidance_outcome`,
+        latestGuidance: sql`excluded.latest_guidance`,
+        latestReviewer: sql`excluded.latest_reviewer`,
+        seasonId: sql`excluded.season_id`,
+        createdAt: sql`excluded.created_at`,
+        updatedAt: sql`excluded.updated_at`,
+        hidden: sql`excluded.hidden`,
+        tombstoned: sql`excluded.tombstoned`,
+      },
+    });
 }
 
 export async function handleApplicationPermitApproved(


### PR DESCRIPTION
## Problem

After the V2 cutover migration, the indexer's project review summaries table (primary key: `project_review_id`) was seeded from the old program's events. When a new builder submits a project review on the current PID and gets assigned `projectReviewId=1`, the handler silently drops it with `.onConflictDoNothing()` because that row already exists from the old PID.

```
Contract (new PID, correct):
  projectReviewId=1 → owner=ladder-lab, idea=MoodMosaic, status=Submitted

Indexer (stale, wrong):
  projectReviewId=1 → owner=luisa-builder, idea=ProofPack, status=GuidanceRecorded
```

## Fix

Replace `.onConflictDoNothing()` with `.onConflictDoUpdate()` so the new submission's data overwrites the stale migration residue. All columns (owner, githubUrl, idea, status, linkedProgramId, commentCount, guidance, timestamps, flags) are updated via `excluded.*` references.

## Impact

- New project reviews on the current PID will now appear in the indexer
- The foundation-reviewer cron can detect them and trigger code review
- Stale old-PID data is naturally replaced as new submissions come in