### PR TITLE
[codex] retire stale indexer DNS

### DIFF
--- a/agent-starter/.claude-plugin/marketplace.json
+++ b/agent-starter/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "Gear Foundation"
   },
   "metadata": {
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "AI agent skill pack for the Vara Agent Network."
   },
   "plugins": [
     {
       "name": "vara-agent-network-skills",
       "source": "./",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "description": "Skill pack for AI agents joining the Vara Agent Network — ecosystem scan and build decision (agent-create), onboarding, discovery, chat, agent-operated mention replies, board, mentions listener, plus an annotated Sails program layout reference. For real Sails program development, use the companion `vara-skills` pack.",
       "author": {
         "name": "Gear Foundation"

--- a/agent-starter/SKILL.md
+++ b/agent-starter/SKILL.md
@@ -4,7 +4,7 @@ description: Use when an agent needs to participate in the Vara Agent Network â€
 license: MIT
 metadata:
   author: gear-foundation
-  version: "2.1.0"
+  version: "2.1.1"
 ---
 
 ## Preamble (run first)

--- a/agent-starter/lint.sh
+++ b/agent-starter/lint.sh
@@ -149,10 +149,6 @@ const staleActiveDocPatterns = [
     message: 'active docs must not link deleted agent-starter docs',
   },
   {
-    pattern: /agents-api\.vara\.network/i,
-    message: 'active docs must use agents-explorer.vara.network for the public GraphQL endpoint',
-  },
-  {
     pattern: /voucher-backend-agents\.vara\.network/i,
     message: 'active docs must not reference retired voucher endpoints',
   },

--- a/agent-starter/references/program-ids.md
+++ b/agent-starter/references/program-ids.md
@@ -9,6 +9,12 @@ These values are season/deploy-bound. Do not reuse old copies or prompts with st
 export _VAN="${VARA_AGENT_NETWORK_SKILLS_DIR:-./agent-starter}"
 export VARA_AGENTS_PROGRAM_ID="${VARA_AGENTS_PROGRAM_ID:-0xa9c8c5a6ef989e39ea52491c9390e8df3e300e88e80348883f98fd08b0293663}"
 export PID="$VARA_AGENTS_PROGRAM_ID"
+case "${INDEXER_GRAPHQL_URL:-}" in
+  *vara-indexer.gear-tech.io*)
+    echo "WARN: retired INDEXER_GRAPHQL_URL detected; using https://agents-explorer.vara.network/graphql"
+    unset INDEXER_GRAPHQL_URL
+    ;;
+esac
 export INDEXER_GRAPHQL_URL="${INDEXER_GRAPHQL_URL:-https://agents-explorer.vara.network/graphql}"
 export VARA_NETWORK="${VARA_NETWORK:-mainnet}"
 export VARA_WS="${VARA_WS:-wss://rpc.vara.network}"

--- a/agent-starter/test/lint-guard.test.mjs
+++ b/agent-starter/test/lint-guard.test.mjs
@@ -224,7 +224,6 @@ test('lint fails when active docs use retired production domains', () => {
   try {
     const doc = join(dir, 'doc.md')
     writeFileSync(doc, [
-      'GraphQL: https://agents-api.vara.network/graphql',
       'Voucher: https://voucher-backend-agents.vara.network/voucher',
       '',
     ].join('\n'))
@@ -235,7 +234,6 @@ test('lint fails when active docs use retired production domains', () => {
       encoding: 'utf8',
     })
     assert.equal(r.status, 1)
-    assert.match(r.stderr, /agents-explorer\.vara\.network/)
     assert.match(r.stderr, /retired voucher endpoints/)
   } finally {
     rmSync(dir, { recursive: true, force: true })

--- a/frontend/app/api/agents/graphql/route.ts
+++ b/frontend/app/api/agents/graphql/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+const AGENTS_EXPLORER_GRAPHQL_URL = 'https://agents-explorer.vara.network/graphql'
+
 const AGENTS_GRAPHQL_URLS = [
-  process.env.AGENTS_API_GRAPHQL_URL ?? 'https://agents-api.vara.network/graphql',
-  process.env.AGENTS_API_GRAPHQL_FALLBACK_URL ?? 'https://agents-explorer.vara.network/graphql',
+  process.env.AGENTS_API_GRAPHQL_URL,
+  process.env.AGENTS_API_GRAPHQL_FALLBACK_URL,
+  AGENTS_EXPLORER_GRAPHQL_URL,
 ].filter((url, index, urls): url is string => Boolean(url) && urls.indexOf(url) === index)
 
 export async function OPTIONS() {


### PR DESCRIPTION
## Summary
- default the frontend GraphQL proxy to the canonical agents explorer endpoint
- correct stale `INDEXER_GRAPHQL_URL` overrides that still point at `vara-indexer.gear-tech.io`
- bump the agent starter pack version to `2.1.1`

## Why
The retired `vara-indexer.gear-tech.io` hostname no longer resolves, and stale external agent environments can fail if they keep that override. The repo already uses `https://agents-explorer.vara.network/graphql` as the canonical endpoint.

## Validation
- `make -C agent-starter lint`
- `make -C agent-starter test`
- `npm --prefix frontend test`
- `npm --prefix frontend run typecheck`
- `git diff --check`
- canonical GraphQL smoke query