### PR TITLE
[codex] Fix agent-starter Result readiness smoke

### DIFF
--- a/agent-starter/agent-board.md
+++ b/agent-starter/agent-board.md
@@ -173,8 +173,15 @@ vara-wallet --account "$ACCT" --network "$VARA_NETWORK" --json call "$PID" \
 For completion evidence, also verify through the indexer that the identity card exists and at least one non-registration announcement is active:
 
 ```bash
+QUERY=$(cat <<EOF
+{
+  identityCardById(id:"$APP_HEX"){id}
+  allAnnouncements(filter:{applicationId:{equalTo:"$APP_HEX"}, archived:{equalTo:false}, kind:{equalTo:"Invitation"}}, first:1){nodes{id title body kind}}
+}
+EOF
+)
 curl -s -X POST "$INDEXER_GRAPHQL_URL" -H 'content-type: application/json' \
-  --data "{\"query\":\"{ identityCardById(id:\\\"$APP_HEX\\\"){id} allAnnouncements(filter:{applicationId:{equalTo:\\\"$APP_HEX\\\"}, archived:{equalTo:false}, kind:{equalTo:\\\"Invitation\\\"}}, first:1){nodes{id title body kind}} }\"}" \
+  --data "$(jq -nc --arg q "$QUERY" '{query:$q}')" \
   | jq '{card_set: (.data.identityCardById != null), manual_post_set: ((.data.allAnnouncements.nodes // []) | length > 0)}'
 ```
 

--- a/agent-starter/scripts/readiness-check.mjs
+++ b/agent-starter/scripts/readiness-check.mjs
@@ -451,6 +451,28 @@ function valueMatchesShape(value, shape) {
   return typeof value === kind ? { ok: true, detail: `result is ${kind}` } : { ok: false, detail: `result is ${typeof value}, expected ${kind}` }
 }
 
+function isResultReturnType(returnType) {
+  const t = String(returnType ?? '').trim()
+  return /^Result<.+,\s*.+>$/.test(t) || /^result\s*\(\s*.+,\s*.+\)$/.test(t)
+}
+
+function smokeValueForShape(returnType, value) {
+  if (!isResultReturnType(returnType)) return { ok: true, value }
+  if (!value || typeof value !== 'object' || Array.isArray(value) || typeof value.kind !== 'string') {
+    return { ok: true, value }
+  }
+  if (value.kind === 'Ok') {
+    return { ok: true, value: Object.prototype.hasOwnProperty.call(value, 'value') ? value.value : null }
+  }
+  if (value.kind === 'Err') {
+    const detail = Object.prototype.hasOwnProperty.call(value, 'value')
+      ? `method returned Err(${JSON.stringify(value.value)})`
+      : 'method returned Err'
+    return { ok: false, detail }
+  }
+  return { ok: true, value }
+}
+
 async function defaultGraphql(url, query, variables) {
   try {
     const res = await fetch(url, {
@@ -606,7 +628,10 @@ async function smokeCheck({ manifest, env, idlText, method, retries, deps }) {
     return check('smoke_ok', 'FAIL', `vara-wallet JSON output could not be parsed: ${e.message}`)
   }
   if (!payload || !('result' in payload)) return check('smoke_ok', 'FAIL', 'vara-wallet output did not contain result')
-  const match = valueMatchesShape(payload.result, manifest.documented_method.expected_return_shape)
+  const smokeValue = smokeValueForShape(method.returnType, payload.result)
+  const match = smokeValue.ok
+    ? valueMatchesShape(smokeValue.value, manifest.documented_method.expected_return_shape)
+    : smokeValue
   return check('smoke_ok', match.ok ? 'PASS' : 'FAIL', match.detail, {
     smoke_command: manifest.smoke_command,
     executed_method: manifest.documented_method.name,

--- a/agent-starter/test/readiness-check.test.mjs
+++ b/agent-starter/test/readiness-check.test.mjs
@@ -383,6 +383,20 @@ service Calc {
   query Compute : () -> result (u32, CalcError);
 };
 `
+const scoreHistoryResultIdl = `type ScoreError = enum { LimitTooLarge };
+type ScoreHistoryPage = struct {
+  items: vec u64,
+  next_cursor: opt u64,
+};
+service Score {
+  query GetScoreHistory : () -> result (ScoreHistoryPage, ScoreError);
+};
+`
+const enumIdl = `type Status = enum { Live };
+service Registry {
+  query GetStatus : () -> Status;
+};
+`
 
 test('documented_method rejects a wrong expected shape against lowercase Sails result (T, E)', async () => {
   const m = manifest({
@@ -403,6 +417,76 @@ test('documented_method accepts a correct shape against lowercase Sails result (
   })
   const output = await runReadinessCheck({ manifest: m, env: env(), deps: deps({ idlText: resultIdl, wallet: { ok: true, status: 0, stdout: '{"result":7}', stderr: '' } }) })
   assert.equal(output.checks.find(c => c.name === 'documented_method').status, 'PASS')
+})
+
+test('smoke_ok validates Sails Result Ok wrappers against the Ok value shape', async () => {
+  const m = manifest({
+    idl_hash: `0x${sha256Hex(Buffer.from(scoreHistoryResultIdl))}`,
+    documented_method: {
+      name: 'Score/GetScoreHistory',
+      example_args: [],
+      expected_return_shape: { kind: 'object', required: ['items', 'next_cursor'] },
+      error_behavior: [{ case: 'bad limit', result: 'Err(LimitTooLarge)' }],
+    },
+    smoke_command: 'vara-wallet --network "$VARA_NETWORK" --json call "$APP_HEX" Score/GetScoreHistory --args "[]" --idl ./score.idl',
+  })
+  const output = await runReadinessCheck({
+    manifest: m,
+    env: env(),
+    deps: deps({
+      idlText: scoreHistoryResultIdl,
+      wallet: { ok: true, status: 0, stdout: '{"result":{"kind":"Ok","value":{"items":[],"next_cursor":null}}}', stderr: '' },
+    }),
+  })
+  assert.equal(output.checks.find(c => c.name === 'smoke_ok').status, 'PASS')
+  assert.equal(output.overall, 'PASS')
+})
+
+test('smoke_ok fails Sails Result Err wrappers clearly', async () => {
+  const m = manifest({
+    idl_hash: `0x${sha256Hex(Buffer.from(scoreHistoryResultIdl))}`,
+    documented_method: {
+      name: 'Score/GetScoreHistory',
+      example_args: [],
+      expected_return_shape: { kind: 'object', required: ['items', 'next_cursor'] },
+      error_behavior: [{ case: 'bad limit', result: 'Err(LimitTooLarge)' }],
+    },
+    smoke_command: 'vara-wallet --network "$VARA_NETWORK" --json call "$APP_HEX" Score/GetScoreHistory --args "[]" --idl ./score.idl',
+  })
+  const output = await runReadinessCheck({
+    manifest: m,
+    env: env(),
+    deps: deps({
+      idlText: scoreHistoryResultIdl,
+      wallet: { ok: true, status: 0, stdout: '{"result":{"kind":"Err","value":"LimitTooLarge"}}', stderr: '' },
+    }),
+  })
+  const smoke = output.checks.find(c => c.name === 'smoke_ok')
+  assert.equal(smoke.status, 'FAIL')
+  assert.match(smoke.detail, /method returned Err/)
+})
+
+test('smoke_ok does not unwrap non-Result enum-shaped objects', async () => {
+  const m = manifest({
+    idl_hash: `0x${sha256Hex(Buffer.from(enumIdl))}`,
+    documented_method: {
+      name: 'Registry/GetStatus',
+      example_args: [],
+      expected_return_shape: { kind: 'object', required: ['kind'] },
+      error_behavior: [{ case: 'unknown app', result: 'null' }],
+    },
+    smoke_command: 'vara-wallet --network "$VARA_NETWORK" --json call "$APP_HEX" Registry/GetStatus --args "[]" --idl ./registry.idl',
+  })
+  const output = await runReadinessCheck({
+    manifest: m,
+    env: env(),
+    deps: deps({
+      idlText: enumIdl,
+      wallet: { ok: true, status: 0, stdout: '{"result":{"kind":"Live"}}', stderr: '' },
+    }),
+  })
+  assert.equal(output.checks.find(c => c.name === 'smoke_ok').status, 'PASS')
+  assert.equal(output.overall, 'PASS')
 })
 
 test('smoke_command accepts --args-file (the pack-recommended long-args path)', async () => {


### PR DESCRIPTION
## Summary
- unwrap Sails `Result` smoke outputs in agent-starter readiness checks before validating expected return shapes
- add regression coverage for `Ok`, `Err`, and non-Result enum-shaped outputs
- replace a brittle inline GraphQL JSON example in `agent-board.md` with heredoc + `jq -nc`

## Root cause
`readiness-check.mjs` already treated `Result<T, E>` IDL return types as the `T` shape for compatibility checks, but smoke validation still checked the raw `vara-wallet` JSON. For Sails queries returning `{ kind: "Ok", value: ... }`, that made valid `Ok` values fail required-field checks.

## Validation
- `rtk make -C agent-starter test`
- `rtk make -C agent-starter lint`
