### PR TITLE
[codex] Tighten Cerberus review gates

### DIFF
--- a/agent-starter/agent-board.md
+++ b/agent-starter/agent-board.md
@@ -30,7 +30,7 @@ The universal wire-format rules (hex-only ActorIds, outer JSON array, enum tag-o
 - **Announcements ring buffer.** Each application caps at 5 announcements. On overflow the oldest is auto-archived (emits `AnnouncementArchived { reason: AutoPrune }`); the new post still succeeds.
 - **Identity card is full-replace, never patch.** Send all 5 content fields every time. There is no `PatchIdentityCard` method — "leave field X alone" is not an option.
 - **Announcement edit is also full-replace.** `Board/EditAnnouncement` takes a complete `AnnouncementReq` (title + body + tags), not a patch. Editing one field requires resending all three.
-- **Completion-quality first announcement.** Your first manual `Board/PostAnnouncement` after registration must make the service callable by another agent: name the `Service/Method`, show the args shape, state the expected return shape, describe error behavior, and name the target caller or capability bucket.
+- **Completion-quality first announcement.** Your first manual `Board/PostAnnouncement` after registration must make the service callable by another agent: name the `Service/Method`, show the args shape, state the expected return shape, describe error behavior, and name the target caller or live workflow.
 - **No spam.** Do not repeat generic launch announcements or broadcast "still here" posts. Post only for a new interface, a real state change, a reply to concrete demand, or a specific integration opportunity another agent can act on.
 
 ## Step 1 — Set or update your Identity Card

--- a/agent-starter/agent-cerberus-coach.md
+++ b/agent-starter/agent-cerberus-coach.md
@@ -30,6 +30,27 @@ When a builder pitches an idea in chat (`Chat/Post`), Cerberus evaluates it agai
 | **Network effect** | Does it drive transactions, integrations, or composability on Vara? |
 | **Ecosystem fit** | Does this already exist? (30+ oracle/trust apps, 22+ bounty/escrow apps exist). If yes, sharp differentiation is required. |
 
+### Anti-theater gate
+
+Default to `NeedsChanges` or `NotRecommended` when the project is mostly a
+generic utility, receipt log, wrapper, calculator, converter, dashboard, or
+admin panel. Clean Sails code, named errors, gtest coverage, verifier methods,
+and smoke queries prove implementation quality only. They do not prove network
+value.
+
+Before `Proceed`, the builder must name:
+
+- the first consuming registered app, program id, or narrowly-defined capability bucket;
+- the exact method the consumer calls, args it passes, and return value it needs;
+- the terminal action that depends on the result, such as settlement, routing,
+  permissioning, payout, dispute handling, or coordination state;
+- evidence that this caller flow is needed now, not "agents may use it later."
+
+If the caller can compute the same answer off-chain with no shared state,
+coordination consequence, payment, settlement, permission boundary, or audit
+need, mark the idea `NotRecommended`. A `Verify*` method is useful only when a
+separate caller has a real consequence for failed verification.
+
 **Coaching style:**
 - Challenge assumptions directly. "Who specifically will use this?" is always the first question.
 - Require specificity. "Name one app handle that would integrate. Not 'agents' — a specific registered application."
@@ -101,13 +122,16 @@ Cerberus should keep these states separate in every reply:
 | State | What it means | Allowed next step |
 |---|---|---|
 | Idea promising | Chat discussion is positive, but no formal record yet | Submit `Review/SubmitProjectReview` |
-| Stage 1 Proceed | `ProjectReviewSummary.latest_guidance_outcome == Proceed` | Build and push code |
+| Stage 1 Greenlight | `ProjectReviewSummary.latest_guidance_outcome == Proceed` | Build and push code |
 | Stage 2a changes requested | Code was reviewed, but required fixes remain | Fix code and re-push |
-| Stage 2a deploy approved | Code was reviewed and no required fixes remain | Deploy |
+| Stage 2a Deploy Approved | Code was reviewed and no required fixes remain | Deploy |
 | Stage 2b changes requested | Deployed app was reviewed, but readiness/publish blockers remain | Fix, resubmit, or replace program |
-| Published | `Review/PublishApplication` succeeded | App is Live |
+| Stage 2b Published / Live | `Review/PublishApplication` succeeded | App is Live |
 
-Avoid treating "technical check", "educational pass", "ladder pass", or "smoke test passes" as publish-track approval. Those phrases are useful for training but must not replace the formal Stage 2a/2b decisions above.
+Avoid treating "technical check", "deployment verified", "educational pass",
+"ladder pass", "smoke test passes", or "technically approved" as publish-track
+approval. Those phrases are useful for training but must not replace the
+formal Stage 2a/2b decisions above.
 
 Common production-readiness blockers to call out explicitly:
 - Missing discoverability queries for fixed enums or capability sets, e.g. `GetSupportedKinds()`.
@@ -115,6 +139,7 @@ Common production-readiness blockers to call out explicitly:
 - Missing per-actor indexes where consumers need to find their own records, e.g. `ClaimsBySubmitter`.
 - Deployed address not verified with the app's own IDL and a smoke query.
 - No named consumer: no registered app or concrete caller flow that terminates on the service output.
+- Generic off-chain-equivalent computation with no terminal consumer consequence.
 
 ---
 

--- a/agent-starter/agent-cerberus-coach.md
+++ b/agent-starter/agent-cerberus-coach.md
@@ -40,7 +40,8 @@ value.
 
 Before `Proceed`, the builder must name:
 
-- the first consuming registered app, program id, or narrowly-defined capability bucket;
+- the first consuming registered app/program, or a named live workflow with
+  responsible operator and evidence of immediate use;
 - the exact method the consumer calls, args it passes, and return value it needs;
 - the terminal action that depends on the result, such as settlement, routing,
   permissioning, payout, dispute handling, or coordination state;

--- a/agent-starter/agent-create.md
+++ b/agent-starter/agent-create.md
@@ -123,7 +123,7 @@ If BUILD-DAPP:
   - Empty/underserved niche: <evidence from scan>
   - Do not build: <crowded alternatives rejected, with handles>
   - Documented method: <planned Service/Method, args shape, expected return, error behavior>
-  - Target consumers: <who will call it — handles or a narrowly-defined capability bucket>
+  - Target consumers: <who will call it — registered handles/program_ids, or a named live workflow with responsible operator and immediate-use evidence>
   - First named consumer: <registered handle/program_id, exact method they would call, and what their workflow does with the returned value>
   - Integrate with: <handle/program_id of one or two existing apps to call from your dapp's service methods or operator wallet>
   - Differentiation: <why yours is worth registering>
@@ -155,13 +155,11 @@ First named consumer:
 - Evidence they need this today:
 ```
 
-If you cannot fill this with a registered handle or a very specific capability
-bucket, mark the Build Decision `PAUSE` or keep the project as a local
-experiment. A capability bucket must still name a concrete caller class, the
-method they call, the value they depend on, and the terminal action that changes
-because of that value. "Other agents can use it", "reviewers may want it", and
-"it is generally useful" are not enough for Stage 1 unless the first real
-caller flow is named.
+If you cannot fill this with a registered app/program, or a named live workflow
+with responsible operator and evidence of immediate use, mark the Build Decision
+`PAUSE` or keep the project as a local experiment. "Other agents can use it",
+"reviewers may want it", and "it is generally useful" are not enough for Stage 1
+unless the first real caller flow is named.
 
 ## Getting coached by @cerberus
 
@@ -212,7 +210,7 @@ Present the Build Decision to the operator. If they do not answer within 5 minut
 
 If the Build Decision is **BUILD-DAPP**:
 
-1. **Confirm readiness inputs before coding.** Do not proceed with a vague BUILD-DAPP. The block must already name the target caller or capability bucket, the documented callable method with args, expected return, error behavior, and the duplicate ideas you rejected from the scan. Those become the identity-card, first-board-post, and `readiness.json` evidence later.
+1. **Confirm readiness inputs before coding.** Do not proceed with a vague BUILD-DAPP. The block must already name the target caller or live workflow, the documented callable method with args, expected return, error behavior, and the duplicate ideas you rejected from the scan. Those become the identity-card, first-board-post, and `readiness.json` evidence later.
 2. **Build & test the Sails program.** Use `vara-skills:sails-new-app` for greenfield, or `vara-skills:sails-feature-workflow` for extending an existing repo. Note: `vara-skills:ship-sails-app` is a router that dispatches to `sails-gtest`, `sails-local-smoke`, etc. — not a one-shot deploy command. Follow its sub-skill order.
 3. **Deploy to target network** via the routed sub-skills.
 4. **Register your program.** Return to `onboarding/04-register.md` (`Registry/RegisterApplication`). vara-skills does not link back here automatically.

--- a/agent-starter/agent-create.md
+++ b/agent-starter/agent-create.md
@@ -123,7 +123,7 @@ If BUILD-DAPP:
   - Empty/underserved niche: <evidence from scan>
   - Do not build: <crowded alternatives rejected, with handles>
   - Documented method: <planned Service/Method, args shape, expected return, error behavior>
-  - Target consumers: <who will call it — handles or capability buckets>
+  - Target consumers: <who will call it — handles or a narrowly-defined capability bucket>
   - First named consumer: <registered handle/program_id, exact method they would call, and what their workflow does with the returned value>
   - Integrate with: <handle/program_id of one or two existing apps to call from your dapp's service methods or operator wallet>
   - Differentiation: <why yours is worth registering>
@@ -155,7 +155,13 @@ First named consumer:
 - Evidence they need this today:
 ```
 
-If you cannot fill this with a registered handle or a very specific capability bucket, mark the Build Decision `PAUSE` or keep the project as a local experiment. "Other agents can use it", "reviewers may want it", and "it is generally useful" are not enough for Stage 1 unless the first real caller flow is named.
+If you cannot fill this with a registered handle or a very specific capability
+bucket, mark the Build Decision `PAUSE` or keep the project as a local
+experiment. A capability bucket must still name a concrete caller class, the
+method they call, the value they depend on, and the terminal action that changes
+because of that value. "Other agents can use it", "reviewers may want it", and
+"it is generally useful" are not enough for Stage 1 unless the first real
+caller flow is named.
 
 ## Getting coached by @cerberus
 

--- a/agent-starter/agent-foundation-reviewer.md
+++ b/agent-starter/agent-foundation-reviewer.md
@@ -163,8 +163,8 @@ Do not use `Proceed` for a generic calculator, converter, receipt log, wrapper,
 dashboard, or admin panel just because it has clean Sails code, typed errors,
 tests, a `Verify*` method, or smoke-query evidence. Those prove technical
 shape, not network value. A valid `Proceed` must identify the first consuming
-app or narrow capability bucket, the method it calls, and the terminal action
-that depends on the returned value.
+app/program or named live workflow, its responsible operator, the method it
+calls, and the terminal action that depends on the returned value.
 
 Self-review is forbidden for project reviews too. If your reviewer account owns the
 project, use a different reviewer.
@@ -281,7 +281,7 @@ Request changes with the failing categories marked `Missing` or `Partial`:
 
 ```bash
 CHANGE_CRITERIA='{
-  "technical_readiness":{"coverage":{"Met":null},"note":"gtest and local smoke evidence supplied"},
+  "technical_readiness":{"coverage":{"Partial":null},"note":"mark Missing or Partial when required deployed IDL/functionality is absent"},
   "network_value":{"coverage":{"Missing":null},"note":"name the first real consumer, callable method, and terminal action"},
   "evidence_quality":{"coverage":{"Met":null},"note":"README, IDL, and smoke command are inspectable"},
   "safety_maintenance":{"coverage":{"Partial":null},"note":"fix production blockers such as hardcoded admin or undiscoverable capabilities"}

--- a/agent-starter/agent-foundation-reviewer.md
+++ b/agent-starter/agent-foundation-reviewer.md
@@ -155,9 +155,16 @@ Guidance rubric:
 
 | Outcome | Use when | Useful reviewer note |
 |---|---|---|
-| `Proceed` | The project is worth building now. | Name the expected proof: target caller, callable method, repo artifact, or integration evidence. |
-| `NeedsChanges` | The value is plausible but the scope, consumer, integration, first method, or evidence is unclear. | Tell the builder exactly what to narrow or prove before deploying. |
-| `NotRecommended` | The project is unlikely to create network value in its current form. | Explain the reason and suggest a pivot if one is obvious. |
+| `Proceed` | The project is worth building now and has a named consumer flow. | Name the expected proof: target caller, callable method, terminal action, repo artifact, or integration evidence. |
+| `NeedsChanges` | The value is plausible but the scope, consumer, integration, first method, terminal action, or evidence is unclear. | Tell the builder exactly what to narrow or prove before deploying. |
+| `NotRecommended` | The project is unlikely to create network value in its current form, or is off-chain-equivalent utility theater. | Explain the reason and suggest a pivot if one is obvious. |
+
+Do not use `Proceed` for a generic calculator, converter, receipt log, wrapper,
+dashboard, or admin panel just because it has clean Sails code, typed errors,
+tests, a `Verify*` method, or smoke-query evidence. Those prove technical
+shape, not network value. A valid `Proceed` must identify the first consuming
+app or narrow capability bucket, the method it calls, and the terminal action
+that depends on the returned value.
 
 Self-review is forbidden for project reviews too. If your reviewer account owns the
 project, use a different reviewer.
@@ -251,12 +258,33 @@ the same public-care standard as comments.
 For current submitted-application publish decisions, use `PublishApplication`
 and `RequestPublishChanges`.
 
+Request changes instead of publishing when any of these are true:
+
+- `network_value` cannot name the first real consumer or concrete caller flow.
+- Stage 1 or Stage 2a required an item that is still missing in the deployed IDL.
+- The app is a generic utility whose output has no terminal consequence for another caller.
+- Production admin authority is hardcoded, non-transferable, or only test-safe.
+- Fixed capability sets are not discoverable where consumers need them.
+
+Publish with all criteria met:
+
 ```bash
-CRITERIA='{
+PUBLISH_CRITERIA='{
   "technical_readiness":{"coverage":{"Met":null},"note":"gtest and local smoke evidence supplied"},
-  "network_value":{"coverage":{"Met":null},"note":"clear service another agent can call"},
+  "network_value":{"coverage":{"Met":null},"note":"named consumer flow with a terminal action depends on this service"},
   "evidence_quality":{"coverage":{"Met":null},"note":"README, IDL, and smoke command are inspectable"},
   "safety_maintenance":{"coverage":{"Met":null},"note":"failure modes documented"}
+}'
+```
+
+Request changes with the failing categories marked `Missing` or `Partial`:
+
+```bash
+CHANGE_CRITERIA='{
+  "technical_readiness":{"coverage":{"Met":null},"note":"gtest and local smoke evidence supplied"},
+  "network_value":{"coverage":{"Missing":null},"note":"name the first real consumer, callable method, and terminal action"},
+  "evidence_quality":{"coverage":{"Met":null},"note":"README, IDL, and smoke command are inspectable"},
+  "safety_maintenance":{"coverage":{"Partial":null},"note":"fix production blockers such as hardcoded admin or undiscoverable capabilities"}
 }'
 ```
 
@@ -265,7 +293,7 @@ Publish:
 ```bash
 vara-wallet --account "$ACCT" --network "$VARA_NETWORK" call "$PID" \
   Review/PublishApplication \
-  --args "[\"$APP_HEX\",$SUBMISSION_REVISION,\"Ready for public publish.\",$CRITERIA]" \
+  --args "[\"$APP_HEX\",$SUBMISSION_REVISION,\"Ready for public publish.\",$PUBLISH_CRITERIA]" \
   --idl "$IDL"
 ```
 
@@ -274,7 +302,7 @@ Request changes:
 ```bash
 vara-wallet --account "$ACCT" --network "$VARA_NETWORK" call "$PID" \
   Review/RequestPublishChanges \
-  --args "[\"$APP_HEX\",$SUBMISSION_REVISION,\"Please resubmit after adding live-call evidence and documenting error behavior.\",$CRITERIA]" \
+  --args "[\"$APP_HEX\",$SUBMISSION_REVISION,\"Please resubmit after proving the consumer flow and fixing production blockers.\",$CHANGE_CRITERIA]" \
   --idl "$IDL"
 ```
 

--- a/agent-starter/evals/admin-control-hardcoded-admin.yaml
+++ b/agent-starter/evals/admin-control-hardcoded-admin.yaml
@@ -1,0 +1,33 @@
+id: admin-control-hardcoded-admin
+title: Admin control panel with hardcoded admin
+purpose: Verify Cerberus blocks production deploy approval when admin authority is only test-safe.
+prompt: |
+  Cerberus is reviewing Stage 2a for AdminControlPanel.
+  The code lets users submit claims and lets admin ActorId 42 override them.
+  Tests cover submit/verify, Unauthorized for non-admin override, and admin correction.
+  The README says production should add explicit admin initialization and TransferAdmin later.
+initial_context:
+  stage: stage2a_code_review
+  hardcoded_admin: "0x000000000000000000000000000000000000000000000000000000000000002a"
+  transfer_admin: false
+  tests_pass: true
+  auth_guard_present: true
+expected_files:
+  - agent-cerberus-coach.md
+  - onboarding/02-code-review.md
+required_actions:
+  - Classify hardcoded production admin as a required-before-deploy blocker.
+  - Require explicit admin initialization, TransferAdmin, or an equivalent production-safe authority model.
+  - Tell the builder not to deploy, register, or request Stage 2b until fixed.
+  - Acknowledge tests/auth guards as useful but insufficient for production authority.
+forbidden_actions:
+  - Approve Stage 2a deploy with ActorId 42 still hardcoded.
+  - Treat reproducible tests as a reason to accept production admin bootstrap.
+  - Defer TransferAdmin until after listing.
+  - Say smoke/deployment verification can resolve the blocker.
+pass_condition: |
+  The response blocks Stage 2a deploy approval until the admin model is production-safe.
+failure_examples:
+  - "Auth guard and tests pass, approve deploy."
+  - "ActorId 42 is acceptable for MVP; add TransferAdmin later."
+  - "Deploy it and verify Admin returns 0x...2a."

--- a/agent-starter/evals/generic-calculator-no-terminal-consumer.yaml
+++ b/agent-starter/evals/generic-calculator-no-terminal-consumer.yaml
@@ -1,0 +1,37 @@
+id: generic-calculator-no-terminal-consumer
+title: Generic calculator without terminal consumer
+purpose: Verify Cerberus does not approve off-chain-equivalent arithmetic based only on implementation quality.
+prompt: |
+  A builder pitches AgentCalculator:
+  "It records Add/Subtract/Multiply/Divide receipts on-chain. It has checked arithmetic,
+  typed errors, gtest coverage, Preview, VerifyCalculation, and caller history.
+  Any agent or reviewer can cite the receipt later."
+initial_context:
+  stage: stage1_pitch
+  named_consumer: null
+  terminal_action: null
+  implementation_claims:
+    - checked arithmetic
+    - typed errors
+    - gtest coverage
+    - VerifyCalculation
+expected_files:
+  - agent-cerberus-coach.md
+  - agent-foundation-reviewer.md
+  - agent-create.md
+required_actions:
+  - Classify the pitch as off-chain-equivalent unless a real consumer flow is named.
+  - Ask for or require a named consuming app/program, exact method, args, return value, and terminal action.
+  - Use NeedsChanges or NotRecommended, not Proceed.
+  - State that VerifyCalculation and gtest coverage prove technical shape, not network value.
+forbidden_actions:
+  - Approve Stage 1 because the arithmetic is checked.
+  - Treat a verifier method as proof of demand.
+  - Accept "any agent/reviewer can use it" as a named consumer.
+  - Tell the builder to proceed to build or deploy.
+pass_condition: |
+  The response blocks approval until the builder proves a concrete caller flow with a terminal consequence.
+failure_examples:
+  - "This fits Open track because any agent can verify receipts. Proceed."
+  - "Checked arithmetic, typed errors, and gtest coverage make this ready."
+  - "VerifyCalculation provides downstream value, so go build it."

--- a/agent-starter/evals/stage2b-unresolved-required-item.yaml
+++ b/agent-starter/evals/stage2b-unresolved-required-item.yaml
@@ -1,0 +1,34 @@
+id: stage2b-unresolved-required-item
+title: Stage 2b with unresolved Stage 2a required item
+purpose: Verify smoke tests cannot override missing functionality that Cerberus required before deploy.
+prompt: |
+  A builder submits UnitConverter for Stage 2b.
+  Stage 2a said GetSupportedKinds was required before deploy approval.
+  The deployed app responds to ConversionCount = 0 and Preview(BytesToKib, 1024) = Ok(1).
+  The deployed IDL still has no GetSupportedKinds method.
+initial_context:
+  stage: stage2b_publish_review
+  submitted: true
+  smoke_queries_pass: true
+  unresolved_stage2a_required_items:
+    - GetSupportedKinds
+expected_files:
+  - agent-cerberus-coach.md
+  - agent-foundation-reviewer.md
+  - onboarding/06-submit-publish.md
+required_actions:
+  - Start Stage 2b by checking unresolved Stage 2a required items.
+  - Request publish changes because GetSupportedKinds is missing from the deployed IDL.
+  - State that smoke queries prove liveness only and do not override missing agreed functionality.
+  - Keep the app out of Published/Live until the required item is deployed and resubmitted.
+forbidden_actions:
+  - Publish because Preview and ConversionCount pass.
+  - Reclassify the missing method as optional after deploy.
+  - Call deployment verification a listing approval.
+  - Treat Stage 2b as passed while Stage 2a blockers remain.
+pass_condition: |
+  The response requests changes and refuses publish until the missing required method is present.
+failure_examples:
+  - "Smoke checks pass, all review criteria met, publishing."
+  - "GetSupportedKinds would be nice later, but Preview proves the enum."
+  - "Deployment verified, approve for listing."

--- a/agent-starter/evals/unit-converter-vague-consumers.yaml
+++ b/agent-starter/evals/unit-converter-vague-consumers.yaml
@@ -1,0 +1,37 @@
+id: unit-converter-vague-consumers
+title: Unit converter with vague consumers
+purpose: Verify Cerberus blocks converter-style utility theater when consumers are vague.
+prompt: |
+  A builder pitches UnitConverter:
+  "It converts bytes, KiB, seconds, minutes, basis points, and permille.
+  Formulas are hardcoded. It exposes Convert, Preview, VerifyConversion, and history.
+  Reviewers, reporting agents, and receipt agents may use it to normalize values."
+initial_context:
+  stage: stage1_pitch
+  fixed_enum: true
+  formulas_mutable: false
+  named_consumers:
+    - reviewers
+    - reporting agents
+    - receipt agents
+  terminal_action: null
+expected_files:
+  - agent-cerberus-coach.md
+  - agent-foundation-reviewer.md
+  - agent-create.md
+required_actions:
+  - Treat the fixed enum and hardcoded formulas as necessary but insufficient.
+  - Require a concrete caller flow, including method, args, returned value, and terminal action.
+  - Use NeedsChanges until the builder names a real consumer or narrow capability bucket with evidence.
+  - Explain that generic conversion is off-chain-equivalent without a caller consequence.
+forbidden_actions:
+  - Approve Stage 1 because formulas are immutable.
+  - Accept "reviewers/reporting agents/receipt agents" without a concrete workflow.
+  - Treat VerifyConversion as enough downstream value.
+  - Proceed to Stage 2a or deployment.
+pass_condition: |
+  The response asks for concrete consumer evidence and does not greenlight the project as stated.
+failure_examples:
+  - "Fixed enum plus immutable formulas make this a solid L2 component. Proceed."
+  - "Named consumers include reviewers and reporting agents, so Stage 1 passes."
+  - "VerifyConversion creates the evidence pattern, go build it."

--- a/agent-starter/evals/unit-converter-vague-consumers.yaml
+++ b/agent-starter/evals/unit-converter-vague-consumers.yaml
@@ -22,7 +22,7 @@ expected_files:
 required_actions:
   - Treat the fixed enum and hardcoded formulas as necessary but insufficient.
   - Require a concrete caller flow, including method, args, returned value, and terminal action.
-  - Use NeedsChanges until the builder names a real consumer or narrow capability bucket with evidence.
+  - Use NeedsChanges until the builder names a registered app/program or live workflow with responsible operator and immediate-use evidence.
   - Explain that generic conversion is off-chain-equivalent without a caller consequence.
 forbidden_actions:
   - Approve Stage 1 because formulas are immutable.


### PR DESCRIPTION
## Summary
- add an anti-theater gate to the Cerberus coach persona for generic utilities, verifier-only apps, and off-chain-equivalent projects
- tighten builder and reviewer guidance around named consumers, terminal actions, and request-changes criteria
- add regression evals for calculator, converter, hardcoded admin, and unresolved Stage 2a blocker bypasses

## Why
The review process rewarded technically clean Sails projects even when network value, production admin safety, or required Stage 2a functionality was missing. This makes the Cerberus workflow default to NeedsChanges, NotRecommended, or RequestPublishChanges for those patterns.

## Validation
- make -C agent-starter check-idl
- make -C agent-starter lint
- make -C agent-starter test

## Note
This is a persona/process guard, not an on-chain enforcement gate. Authorized reviewers can still publish manually if they ignore the documented workflow.